### PR TITLE
Workaround for 2.34.4 wrong href value

### DIFF
--- a/src/data/Dhis2ConfigRepository.ts
+++ b/src/data/Dhis2ConfigRepository.ts
@@ -8,7 +8,6 @@ import { User } from "../domain/entities/User";
 const base = {
     dataSets: { namePrefix: "NHWA", nameExcluded: /old$/ },
     sqlViewName: "NHWA Data Comments",
-    sectionOrderAttributeCode: "SECTION_ORDER",
     constantCode: "NHWA_COMMENTS",
 };
 
@@ -16,11 +15,9 @@ export class Dhis2ConfigRepository implements ConfigRepository {
     constructor(private api: D2Api) {}
 
     async get(): Promise<Config> {
-        const { dataSets, constants, sqlViews, attributes } = await this.getMetadata();
+        const { dataSets, constants, sqlViews } = await this.getMetadata();
         const filteredDataSets = getFilteredDataSets(dataSets);
-        const attributeCode = base.sectionOrderAttributeCode;
         const getDataValuesSqlView = getFirst(sqlViews, `Missing sqlView: ${base.sqlViewName}`);
-        const sectionOrderAttribute = getFirst(attributes, `Missing attribute: ${attributeCode}`);
         const constant = getFirst(constants, `Missing constant: ${base.constantCode}`);
         const currentUser = await this.getCurrentUser();
         const pairedDataElements = getPairedMapping(filteredDataSets);
@@ -32,7 +29,6 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             dataSets: keyById(filteredDataSets),
             currentUser,
             getDataValuesSqlView,
-            sectionOrderAttribute,
             pairedDataElementsByDataSet: pairedDataElements,
             sections: keyById(sections),
             sectionsByDataSet,
@@ -59,10 +55,6 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             sqlViews: {
                 fields: { id: true },
                 filter: { name: { eq: base.sqlViewName } },
-            },
-            attributes: {
-                fields: { id: true },
-                filter: { code: { eq: base.sectionOrderAttributeCode } },
             },
         });
 

--- a/src/data/Dhis2DataValueRepository.ts
+++ b/src/data/Dhis2DataValueRepository.ts
@@ -17,7 +17,6 @@ interface Variables {
     periods: string;
     orderByColumn: SqlField;
     orderByDirection: "asc" | "desc";
-    sectionOrderAttributeId: Id;
     commentPairs: string;
 }
 
@@ -75,7 +74,6 @@ export class Dhis2DataValueRepository implements DataValueRepository {
                     orderByColumn: fieldMapping[sorting.field],
                     orderByDirection: sorting.direction,
                     commentPairs,
-                    sectionOrderAttributeId: config.sectionOrderAttribute.id,
                 },
                 paging
             )

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -4,7 +4,6 @@ import { User } from "./User";
 export interface Config {
     dataSets: Record<Id, NamedRef>;
     sections: Record<Id, NamedRef>;
-    sectionOrderAttribute: Ref;
     currentUser: User;
     getDataValuesSqlView: Ref;
     pairedDataElementsByDataSet: {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,7 +15,8 @@ async function getBaseUrl() {
         return baseUrl.replace(/\/*$/, "");
     } else {
         const { data: manifest } = await axios.get("manifest.webapp");
-        return manifest.activities.dhis.href;
+        const href = manifest.activities.dhis.href;
+        return href === "*" ? ".." : href;
     }
 }
 

--- a/src/webapp/components/app/App.css
+++ b/src/webapp/components/app/App.css
@@ -11,3 +11,7 @@ body {
 li {
     line-height: 1.75;
 }
+
+table th, table td {
+    border: none !important
+}


### PR DESCRIPTION
Workaround for 2.34.3 returning manifest -> activities > dhis -> href *, the raw value, instead of the expected "..".

Also, removed unused attribute from the metadata.

---
Docs: https://docs.dhis2.org/2.35/en/developer/html/dhis2_developer_manual_full.html#apps_creating_apps