### PR TITLE
Feature/orgunit popup filter f6zwjh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ cypress/videos/
 
 # Custom
 bak
+NOTES*

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
 ## Introduction
 
-_d2-report_ provides the infrastructure to create DHIS2 reports with a React frontend.
-
-Those reports developed an an standard webapp, and they can both be used as an standalone DHIS2 webapp or an standard HTML report (App: Reports).
-
-Target DHIS2: 2.34.
+_d2-reports_ than can be used as an standalone DHIS2 webapp or an standard HTML report (App: Reports). DHIS2 versions tested: 2.34.
 
 ## Reports
 
@@ -15,12 +11,10 @@ This report shows data values for data sets `NHWA Module ...`. There are two kin
 1. Data values that have comments.
 2. Data values related pairs (value/comment), which are rendered as a single row. The pairing criteria is:
 
-    - Comment data element: `NHWA_Comment of Abc`.
+    - Comment data element `NHWA_Comment of Abc`.
     - Value data element: `NHWA_Abc`.
 
-The API endpoint `/dataValueSets` does not provide all the features we need, so we use a custom SQL View instead. It will be included in the metadata.
-
-We use the data element group to put data elements in the same sections together. Note that only data elements belonging to a data element group will be displayed.
+The API endpoint `/dataValueSets` does not provide all the features we need, so we use a custom SQL View instead.
 
 ## Initial setup
 
@@ -30,7 +24,7 @@ $ yarn install
 
 ## Development
 
-Start development server at `http://localhost:8082` using `https://play.dhis2.org/2.34` as backend:
+Start the development server at `http://localhost:8082` using `https://play.dhis2.org/2.34` as a backend:
 
 ```
 $ PORT=8082 REACT_APP_DHIS2_BASE_URL="https://play.dhis2.org/2.34" yarn start
@@ -38,16 +32,16 @@ $ PORT=8082 REACT_APP_DHIS2_BASE_URL="https://play.dhis2.org/2.34" yarn start
 
 ## Deploy
 
-Create standard report:
+Create an standard report:
 
 ```
-$ yarn build-report # Create dist/index.html
-$ yarn build-metadata -u 'user:password' http://dhis2-server.org # Creates dist/metadata.json
-$ yarn post-metadata -u 'user:password' http://dhis2-server.org # Posts dist/metadata.json
+$ yarn build-report # Creates dist/index.html
+$ yarn build-metadata -u 'user:pass' http://dhis2-server.org # Creates dist/metadata.json
+$ yarn post-metadata -u 'user:pass' http://dhis2-server.org # Posts dist/metadata.json
 ```
 
-Create web-app zip (`dist/d2-reports.zip`):
+Create an standalone DHIS2 webapp app:
 
 ```
-$ yarn build-webapp
+$ yarn build-webapp # Creates dist/d2-reports.zip
 ```

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-11-18T10:58:48.575Z\n"
-"PO-Revision-Date: 2020-11-18T10:58:48.575Z\n"
+"POT-Creation-Date: 2021-03-05T08:55:57.149Z\n"
+"PO-Revision-Date: 2021-03-05T08:55:57.149Z\n"
 
 msgid "Periods"
 msgstr ""
@@ -15,6 +15,9 @@ msgid "Data sets"
 msgstr ""
 
 msgid "Sections"
+msgstr ""
+
+msgid "NHWA Comments Report"
 msgstr ""
 
 msgid "Data set"
@@ -45,6 +48,18 @@ msgid "Last updated"
 msgstr ""
 
 msgid "Stored by"
+msgstr ""
+
+msgid "Toggle filters"
+msgstr ""
+
+msgid "Loading..."
+msgstr ""
+
+msgid "Select parent organisation unit"
+msgstr ""
+
+msgid "Close"
 msgstr ""
 
 msgid "<No value>"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2020-11-18T10:58:48.575Z\n"
+"POT-Creation-Date: 2021-03-05T08:55:57.149Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -15,6 +15,9 @@ msgid "Data sets"
 msgstr ""
 
 msgid "Sections"
+msgstr ""
+
+msgid "NHWA Comments Report"
 msgstr ""
 
 msgid "Data set"
@@ -45,6 +48,18 @@ msgid "Last updated"
 msgstr ""
 
 msgid "Stored by"
+msgstr ""
+
+msgid "Toggle filters"
+msgstr ""
+
+msgid "Loading..."
+msgstr ""
+
+msgid "Select parent organisation unit"
+msgstr ""
+
+msgid "Close"
 msgstr ""
 
 msgid "<No value>"

--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -4,15 +4,21 @@ import { GetDataValuesUseCase } from "./domain/usecases/GetDataValuesUseCase";
 import { GetConfig } from "./domain/usecases/GetConfig";
 import { Dhis2ConfigRepository } from "./data/Dhis2ConfigRepository";
 import { SaveDataValuesUseCase } from "./domain/usecases/SaveDataValuesCsvUseCase";
+import { GetOrgUnitsUseCase } from "./domain/usecases/GetOrgUnitsUseCase";
+import { Dhis2OrgUnitsRepository } from "./data/Dhis2OrgUnitsRepository";
 
 export function getCompositionRoot(api: D2Api) {
     const configRepository = new Dhis2ConfigRepository(api);
     const dataValueRepository = new Dhis2DataValueRepository(api);
+    const orgUnitsRepository = new Dhis2OrgUnitsRepository(api);
 
     return {
         dataValues: {
             get: new GetDataValuesUseCase(dataValueRepository),
             save: new SaveDataValuesUseCase(dataValueRepository),
+        },
+        orgUnits: {
+            get: new GetOrgUnitsUseCase(orgUnitsRepository),
         },
         config: {
             get: new GetConfig(configRepository),

--- a/src/data/Dhis2OrgUnitsRepository.ts
+++ b/src/data/Dhis2OrgUnitsRepository.ts
@@ -1,0 +1,22 @@
+import { OrgUnitPath, OrgUnit, getOrgUnitIdsFromPaths } from "../domain/entities/OrgUnit";
+import { OrgUnitsRepository } from "../domain/repositories/OrgUnitsRepository";
+import { D2Api } from "../types/d2-api";
+
+export class Dhis2OrgUnitsRepository implements OrgUnitsRepository {
+    constructor(private api: D2Api) {}
+
+    async getFromPaths(paths: OrgUnitPath[]): Promise<OrgUnit[]> {
+        const ids = getOrgUnitIdsFromPaths(paths);
+
+        const { organisationUnits } = await this.api.metadata
+            .get({
+                organisationUnits: {
+                    filter: { id: { in: ids } },
+                    fields: { id: true, path: true, name: true, level: true },
+                },
+            })
+            .getData();
+
+        return organisationUnits;
+    }
+}

--- a/src/domain/entities/Config.ts
+++ b/src/domain/entities/Config.ts
@@ -1,4 +1,6 @@
+import _ from "lodash";
 import { Id, NamedRef, Ref } from "./Base";
+import { getPath } from "./OrgUnit";
 import { User } from "./User";
 
 export interface Config {
@@ -13,4 +15,8 @@ export interface Config {
         [dataSetId: string]: NamedRef[];
     };
     years: string[];
+}
+
+export function getMainUserPaths(config: Config) {
+    return _.compact([getPath(config.currentUser.orgUnits)]);
 }

--- a/src/domain/entities/OrgUnit.ts
+++ b/src/domain/entities/OrgUnit.ts
@@ -1,14 +1,16 @@
 import _ from "lodash";
 import { Id } from "./Base";
 
-type Path = string;
+export type OrgUnitPath = string;
 
 export interface OrgUnit {
-    id: string;
-    path: Path;
+    id: Id;
+    path: OrgUnitPath;
     name: string;
     level: number;
 }
+
+const pathSeparator = "/";
 
 export function getRoots(orgUnits: OrgUnit[]): OrgUnit[] {
     const minLevel = _.min(orgUnits.map(ou => ou.level));
@@ -22,13 +24,17 @@ export function getRootIds(orgUnits: OrgUnit[]): Id[] {
     return getRoots(orgUnits).map(ou => ou.id);
 }
 
-export function getPath(orgUnits: OrgUnit[]): Path | undefined {
+export function getPath(orgUnits: OrgUnit[]): OrgUnitPath | undefined {
     return getRoots(orgUnits).map(ou => ou.path)[0];
 }
 
-export function getOrgUnitIdsFromPaths(orgUnitPathsSelected: Path[]): Id[] {
+export function getOrgUnitIdsFromPaths(orgUnitPathsSelected: OrgUnitPath[]): Id[] {
     return _(orgUnitPathsSelected)
-        .map(path => _.last(path.split("/")))
+        .map(path => _.last(path.split(pathSeparator)))
         .compact()
         .value();
+}
+
+export function getOrgUnitParentPath(path: OrgUnitPath) {
+    return _(path).split(pathSeparator).initial().join(pathSeparator);
 }

--- a/src/domain/repositories/OrgUnitsRepository.ts
+++ b/src/domain/repositories/OrgUnitsRepository.ts
@@ -1,0 +1,5 @@
+import { OrgUnit, OrgUnitPath } from "../entities/OrgUnit";
+
+export interface OrgUnitsRepository {
+    getFromPaths(paths: OrgUnitPath[]): Promise<OrgUnit[]>;
+}

--- a/src/domain/usecases/GetOrgUnitsUseCase.ts
+++ b/src/domain/usecases/GetOrgUnitsUseCase.ts
@@ -1,0 +1,10 @@
+import { OrgUnit, OrgUnitPath } from "../entities/OrgUnit";
+import { OrgUnitsRepository } from "../repositories/OrgUnitsRepository";
+
+export class GetOrgUnitsUseCase {
+    constructor(private orgUnitsRepository: OrgUnitsRepository) {}
+
+    execute(options: { paths: OrgUnitPath[] }): Promise<OrgUnit[]> {
+        return this.orgUnitsRepository.getFromPaths(options.paths);
+    }
+}

--- a/src/webapp/components/app/App.css
+++ b/src/webapp/components/app/App.css
@@ -12,6 +12,7 @@ li {
     line-height: 1.75;
 }
 
-table th, table td {
-    border: none !important
+table th,
+table td {
+    border: none !important;
 }

--- a/src/webapp/components/data-values-list/DataValuesFilters.tsx
+++ b/src/webapp/components/data-values-list/DataValuesFilters.tsx
@@ -2,14 +2,18 @@ import React from "react";
 import i18n from "../../../locales";
 import MultipleDropdown from "../../components/dropdown/MultipleDropdown";
 import { Id, NamedRef } from "../../../domain/entities/Base";
+import { useAppContext } from "../../contexts/app-context";
+import { getRootIds } from "../../../domain/entities/OrgUnit";
+import { OrgUnitsFilterButton } from "./OrgUnitsFilterButton";
 
-interface DataValuesFiltersProps {
+export interface DataValuesFiltersProps {
     values: DataValuesFilter;
     options: FilterOptions;
     onChange(newFilters: DataValuesFilter): void;
 }
 
 export interface DataValuesFilter {
+    orgUnitPaths: Id[];
     periods: string[];
     dataSetIds: Id[];
     sectionIds: Id[];
@@ -22,25 +26,36 @@ interface FilterOptions {
 }
 
 export const DataValuesFilters: React.FC<DataValuesFiltersProps> = React.memo(props => {
+    const { config, api } = useAppContext();
     const { values: filter, options: filterOptions, onChange } = props;
     const periodItems = useMemoOptionsFromStrings(filterOptions.periods);
     const dataSetItems = useMemoOptionsFromNamedRef(filterOptions.dataSets);
     const sectionItems = useMemoOptionsFromNamedRef(filterOptions.sections);
+    const rootIds = React.useMemo(() => getRootIds(config.currentUser.orgUnits), [config]);
 
     return (
         <div>
+            <OrgUnitsFilterButton
+                api={api}
+                rootIds={rootIds}
+                selected={filter.orgUnitPaths}
+                setSelected={paths => onChange({ ...filter, orgUnitPaths: paths })}
+            />
+
             <MultipleDropdown
                 items={periodItems}
                 values={filter.periods}
                 onChange={periods => onChange({ ...filter, periods })}
                 label={i18n.t("Periods")}
             />
+
             <MultipleDropdown
                 items={dataSetItems}
                 values={filter.dataSetIds}
                 onChange={dataSetIds => onChange({ ...filter, dataSetIds })}
                 label={i18n.t("Data sets")}
             />
+
             <MultipleDropdown
                 items={sectionItems}
                 values={filter.sectionIds}
@@ -62,9 +77,3 @@ function useMemoOptionsFromNamedRef(options: NamedRef[]) {
         return options.map(option => ({ value: option.id, text: option.name }));
     }, [options]);
 }
-
-export const emptyDataValuesFilter: DataValuesFilter = {
-    periods: [],
-    dataSetIds: [],
-    sectionIds: [],
-};

--- a/src/webapp/components/data-values-list/FiltersBox.tsx
+++ b/src/webapp/components/data-values-list/FiltersBox.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import _ from "lodash";
+import { IconButton } from "material-ui";
+import { FilterList } from "@material-ui/icons";
+import { DataValuesFilters, DataValuesFiltersProps } from "./DataValuesFilters";
+import { useBooleanState } from "../../utils/use-boolean";
+import i18n from "../../../locales";
+
+export interface FiltersBoxProps extends DataValuesFiltersProps {
+    showToggleButton: boolean;
+}
+
+export const FiltersBox: React.FC<FiltersBoxProps> = React.memo(props => {
+    const { showToggleButton = true, ...otherProps } = props;
+    const areFiltersApplied = !_(props.values).values().every(_.isEmpty);
+    const [isFilterBoxVisible, { toggle: toggleFilterBoxVisibility }] = useBooleanState(false);
+    const filterIconColor = areFiltersApplied ? "#ff9800" : undefined;
+    const filterButtonColor = isFilterBoxVisible ? { backgroundColor: "#cdcdcd" } : undefined;
+    const areFiltersVisible = !showToggleButton || isFilterBoxVisible;
+    const filtersStyle = areFiltersVisible ? styles.filters.visible : styles.filters.hidden;
+
+    return (
+        <React.Fragment>
+            {showToggleButton && (
+                <IconButton
+                    onClick={toggleFilterBoxVisibility}
+                    title={i18n.t("Toggle filters")}
+                    style={filterButtonColor}
+                >
+                    <FilterList style={{ color: filterIconColor }} />
+                </IconButton>
+            )}
+
+            <div style={filtersStyle}>
+                <DataValuesFilters {...otherProps} />
+            </div>
+        </React.Fragment>
+    );
+});
+
+const styles = {
+    filters: {
+        visible: {},
+        hidden: { display: "none" },
+    },
+};

--- a/src/webapp/components/data-values-list/OrgUnitsFilter.tsx
+++ b/src/webapp/components/data-values-list/OrgUnitsFilter.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import _ from "lodash";
 import { D2Api } from "../../../types/d2-api";
 import { OrgUnitsSelector } from "d2-ui-components";
 import { makeStyles } from "@material-ui/core";
@@ -17,7 +18,9 @@ const orgUnitsSelectorControls = {};
 export const OrgUnitsFilter: React.FC<OrgUnitsFilterProps> = React.memo(props => {
     const { api, rootIds, selected, setSelected } = props;
     const classes = useStyles();
-    const initiallyExpanded = React.useMemo(() => selected.map(getOrgUnitParentPath), [selected]);
+    const initiallyExpanded = React.useMemo(() => _.compact(selected.map(getOrgUnitParentPath)), [
+        selected,
+    ]);
 
     return (
         <div key={"org-unit-selector-filter"} className={classes.orgUnitFilter}>

--- a/src/webapp/components/data-values-list/OrgUnitsFilter.tsx
+++ b/src/webapp/components/data-values-list/OrgUnitsFilter.tsx
@@ -3,19 +3,21 @@ import { D2Api } from "../../../types/d2-api";
 import { OrgUnitsSelector } from "d2-ui-components";
 import { makeStyles } from "@material-ui/core";
 import { Id } from "../../../domain/entities/Base";
+import { getOrgUnitParentPath, OrgUnitPath } from "../../../domain/entities/OrgUnit";
 
-interface OrgUnitsFilterProps {
+export interface OrgUnitsFilterProps {
     api: D2Api;
     rootIds: Id[];
-    selected: Path[];
-    setSelected(newPaths: Path[]): void;
+    selected: OrgUnitPath[];
+    setSelected(newPaths: OrgUnitPath[]): void;
 }
 
-type Path = string;
+const orgUnitsSelectorControls = {};
 
 export const OrgUnitsFilter: React.FC<OrgUnitsFilterProps> = React.memo(props => {
     const { api, rootIds, selected, setSelected } = props;
     const classes = useStyles();
+    const initiallyExpanded = React.useMemo(() => selected.map(getOrgUnitParentPath), [selected]);
 
     return (
         <div key={"org-unit-selector-filter"} className={classes.orgUnitFilter}>
@@ -33,13 +35,11 @@ export const OrgUnitsFilter: React.FC<OrgUnitsFilterProps> = React.memo(props =>
                 selected={selected}
                 singleSelection={true}
                 selectOnClick={true}
-                initiallyExpanded={[]}
+                initiallyExpanded={initiallyExpanded}
             />
         </div>
     );
 });
-
-const orgUnitsSelectorControls = {};
 
 const useStyles = makeStyles({
     orgUnitFilter: {

--- a/src/webapp/components/data-values-list/OrgUnitsFilterButton.tsx
+++ b/src/webapp/components/data-values-list/OrgUnitsFilterButton.tsx
@@ -26,6 +26,7 @@ export const OrgUnitsFilterButton: React.FC<OrgUnitsFilterButtonProps> = React.m
         <React.Fragment>
             <span onClick={openDialog} style={styles.textField}>
                 <TextField
+                    title={selectedOrgUnits}
                     value={selectedOrgUnits}
                     onChange={closeDialog}
                     floatingLabelText={i18n.t("Organisation unit")}

--- a/src/webapp/components/data-values-list/OrgUnitsFilterButton.tsx
+++ b/src/webapp/components/data-values-list/OrgUnitsFilterButton.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { OrgUnitsFilter, OrgUnitsFilterProps } from "./OrgUnitsFilter";
+import { ConfirmationDialog } from "d2-ui-components";
+import i18n from "../../../locales";
+import { TextField } from "material-ui";
+import { useBooleanState } from "../../utils/use-boolean";
+import { useAppContext } from "../../contexts/app-context";
+
+export interface OrgUnitsFilterButtonProps extends OrgUnitsFilterProps {}
+
+export const OrgUnitsFilterButton: React.FC<OrgUnitsFilterButtonProps> = React.memo(props => {
+    const { compositionRoot } = useAppContext();
+    const [isDialogOpen, { enable: openDialog, disable: closeDialog }] = useBooleanState(false);
+    const loadingMessage = i18n.t("Loading...");
+    const [selectedOrgUnits, setSelectedOrgUnits] = React.useState(loadingMessage);
+
+    React.useEffect(() => {
+        setSelectedOrgUnits(loadingMessage);
+        compositionRoot.orgUnits.get
+            .execute({ paths: props.selected })
+            .then(orgUnits => setSelectedOrgUnits(orgUnits.map(ou => ou.name).join(", ")))
+            .catch(() => setSelectedOrgUnits(props.selected.join(", ")));
+    }, [compositionRoot, props.selected, loadingMessage]);
+
+    return (
+        <React.Fragment>
+            <span onClick={openDialog} style={styles.textField}>
+                <TextField
+                    value={selectedOrgUnits}
+                    onChange={closeDialog}
+                    floatingLabelText={i18n.t("Organisation unit")}
+                />
+            </span>
+
+            <ConfirmationDialog
+                isOpen={isDialogOpen}
+                onClose={closeDialog}
+                onSave={closeDialog}
+                title={i18n.t("Select parent organisation unit")}
+                saveText={i18n.t("Close")}
+            >
+                <OrgUnitsFilter {...props} />
+            </ConfirmationDialog>
+        </React.Fragment>
+    );
+});
+
+const styles = {
+    textField: { display: "inline-flex", marginTop: -24 },
+};

--- a/src/webapp/utils/use-boolean.ts
+++ b/src/webapp/utils/use-boolean.ts
@@ -1,0 +1,27 @@
+import React from "react";
+
+type Callback = () => void;
+
+type UseBooleanReturn = [boolean, UseBooleanActions];
+
+interface UseBooleanActions {
+    set: (newValue: boolean) => void;
+    toggle: Callback;
+    enable: Callback;
+    disable: Callback;
+}
+
+export function useBooleanState(initialValue: boolean): UseBooleanReturn {
+    const [value, setValue] = React.useState(initialValue);
+
+    const actions = React.useMemo(() => {
+        return {
+            set: (newValue: boolean) => setValue(newValue),
+            enable: () => setValue(true),
+            disable: () => setValue(false),
+            toggle: () => setValue(value_ => !value_),
+        };
+    }, [setValue]);
+
+    return [value, actions];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4196,9 +4196,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001035, caniuse-lite@^1.0.30001087, caniuse-lite@^1.0.30001088:
-  version "1.0.30001093"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001093.tgz#833e80f64b1a0455cbceed2a4a3baf19e4abd312"
-  integrity sha512-0+ODNoOjtWD5eS9aaIpf4K0gQqZfILNY4WSNuYzeT1sXni+lMrrVjc0odEobJt6wrODofDZUX8XYi/5y7+xl8g==
+  version "1.0.30001196"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001196.tgz"
+  integrity sha512-CPvObjD3ovWrNBaXlAIGWmg2gQQuJ5YhuciUOjPRox6hIQttu8O+b51dx6VIpIY9ESd2d0Vac1RKpICdG4rGUg==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/f6zwjh

### :memo: Implementation

We first thought about using a material-UI drawer (like the one we have abstracted in bulk-load), but a component that overlays the full viewport is visually more fitted for global menus of an app, not for a specific sidebar like this. So we've finally applied **the idea of user-extended-app**: a `TextField `which shows the current org unit selected and opens a dialog on click.

### :art: Screenshots

![image](https://user-images.githubusercontent.com/24643/110293991-8e862780-7fef-11eb-8127-d5e46043f26c.png)


### :fire: Notes to the tester

Follow deploy notes on https://github.com/EyeSeeTea/d2-reports#deploy
