### PR TITLE
Read dates as per the browser, write dates as per UTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "d2": "31.10.2",
         "d2-manifest": "1.0.0",
         "date-fns": "^2.29.2",
+        "date-fns-tz": "^1.3.7",
         "dotenv-flow": "3.2.0",
         "font-awesome": "4.7.0",
         "lodash": "4.17.21",

--- a/src/webapp/reports/mal-dataset-duplication/DataApprovalViewModel.ts
+++ b/src/webapp/reports/mal-dataset-duplication/DataApprovalViewModel.ts
@@ -3,6 +3,7 @@ import {
     DataDuplicationItem,
     getDataDuplicationItemId,
 } from "../../../domain/mal-dataset-duplication/entities/DataDuplicationItem";
+import { toDate } from 'date-fns-tz';
 
 export interface DataApprovalViewModel {
     id: string;
@@ -35,9 +36,9 @@ export function getDataApprovalViews(_config: Config, items: DataDuplicationItem
             approvalWorkflow: item.approvalWorkflow ?? "-",
             completed: item.completed,
             validated: item.validated,
-            lastUpdatedValue: item.lastUpdatedValue ? new Date(item.lastUpdatedValue) : undefined,
-            lastDateOfSubmission: item.lastDateOfSubmission ? new Date(item.lastDateOfSubmission) : undefined,
-            lastDateOfApproval: item.lastDateOfApproval ? new Date(item.lastDateOfApproval) : undefined,
+            lastUpdatedValue: item.lastUpdatedValue ? toDate(item.lastUpdatedValue, { timeZone: "UTC" }) : undefined,
+            lastDateOfSubmission: item.lastDateOfSubmission ? toDate(item.lastDateOfSubmission, { timeZone: "UTC" }) : undefined,
+            lastDateOfApproval: item.lastDateOfApproval ? toDate(item.lastDateOfApproval, { timeZone: "UTC" }) : undefined,
         };
     });
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [Read dates as per the browser, write dates as per UTC](https://app.clickup.com/t/2y2jk8x)

### :memo: Implementation

The date is written in "yyyy-MM-dd'T'HH:mm" format onto the DB, so when reading it, it comes without TZ code.
So, the dates were imported without timezone, thus assuming the browser timezone as the date TZ instead of UTC.
This is fixed now in the `getDataApprovalViews()` function.
