### PR TITLE
Disable actions for empty rows

### DIFF
--- a/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
@@ -121,7 +121,10 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: rows => _.every(rows, row => row.completed === false) && (isMalApprover || isMalAdmin),
+                    isActive: (rows: DataApprovalViewModel[]) => {return _.every(rows, row => row.completed === false 
+                        && row.lastUpdatedValue) 
+                        && (isMalApprover || isMalAdmin)
+                    },
                 },
                 {
                     name: "incomplete",
@@ -153,7 +156,10 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: rows => _.every(rows, row => row.validated === false) && (isMalApprover || isMalAdmin),
+                    isActive: (rows: DataApprovalViewModel[]) => {return _.every(rows, row => row.validated === false 
+                        && row.lastUpdatedValue) 
+                        && (isMalApprover || isMalAdmin)
+                    },
                 },
                 {
                     name: "unapprove",
@@ -185,7 +191,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: () => isMalAdmin,
+                    isActive: rows => _.every(rows, row => row.lastUpdatedValue) && isMalAdmin,
                 },
                 {
                     name: "getDiff",
@@ -196,7 +202,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                         openDialog();
                         setSelected(selectedIds);
                     },
-                    isActive: () => isMalApprover || isMalAdmin,
+                    isActive: rows => _.every(rows, row => row.lastUpdatedValue) && (isMalApprover || isMalAdmin),
                 },
             ],
             initialSorting: {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** No specific issue, parent task: [Development of the mockup](https://app.clickup.com/t/1z0j4xr)

### :memo: Implementation

If a row has no dataValues the complete, submit, approve and compare actions are disabled.
The incomplete and revoke actions does not perform this check.
