### PR TITLE
Selected columns are in blank right after compiling the report

### DIFF
--- a/src/data/MALDataDuplicationDefaultRepository.ts
+++ b/src/data/MALDataDuplicationDefaultRepository.ts
@@ -12,7 +12,6 @@ import {
 import { D2Api, Id, PaginatedObjects } from "../types/d2-api";
 import { promiseMap } from "../utils/promises";
 import { DataStoreStorageClient } from "./clients/storage/DataStoreStorageClient";
-import { Namespaces } from "./clients/storage/Namespaces";
 import { StorageClient } from "./clients/storage/StorageClient";
 import { CsvData } from "./CsvDataSource";
 import { CsvWriterDataSource } from "./CsvWriterCsvDataSource";

--- a/src/data/MALDataDuplicationDefaultRepository.ts
+++ b/src/data/MALDataDuplicationDefaultRepository.ts
@@ -424,14 +424,14 @@ export class MALDataDuplicationDefaultRepository implements MALDataDuplicationRe
         }
     }
 
-    async getColumns(): Promise<string[]> {
-        const columns = await this.storageClient.getObject<string[]>(Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS);
+    async getColumns(namespace: string): Promise<string[]> {
+        const columns = await this.storageClient.getObject<string[]>(namespace);
 
         return columns ?? [];
     }
 
-    async saveColumns(columns: string[]): Promise<void> {
-        return this.storageClient.saveObject<string[]>(Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS, columns);
+    async saveColumns(namespace: string, columns: string[]): Promise<void> {
+        return this.storageClient.saveObject<string[]>(namespace, columns);
     }
 }
 

--- a/src/data/clients/storage/Namespaces.ts
+++ b/src/data/clients/storage/Namespaces.ts
@@ -6,9 +6,11 @@ export type Namespace = typeof Namespaces[keyof typeof Namespaces];
 export const Namespaces = {
     NHWA_APPROVAL_STATUS_USER_COLUMNS: "nhwa-approval-status-user-columns",
     MAL_APPROVAL_STATUS_USER_COLUMNS: "mal-approval-status-user-columns",
+    MAL_DIFF_STATUS_USER_COLUMNS: "mal-diff-status-user-columns",
 };
 
 export const NamespaceProperties: Record<Namespace, string[]> = {
     [Namespaces.NHWA_APPROVAL_STATUS_USER_COLUMNS]: [],
     [Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS]: [],
+    [Namespaces.MAL_DIFF_STATUS_USER_COLUMNS]: [],
 };

--- a/src/domain/mal-dataset-duplication/repositories/MALDataDuplicationRepository.ts
+++ b/src/domain/mal-dataset-duplication/repositories/MALDataDuplicationRepository.ts
@@ -13,8 +13,8 @@ export interface MALDataDuplicationRepository {
     duplicate(dataSets: DataDuplicationItemIdentifier[]): Promise<boolean>;
     incomplete(dataSets: DataDuplicationItemIdentifier[]): Promise<boolean>;
     unapprove(dataSets: DataDuplicationItemIdentifier[]): Promise<boolean>;
-    getColumns(): Promise<string[]>;
-    saveColumns(columns: string[]): Promise<void>;
+    getColumns(namespace: string): Promise<string[]>;
+    saveColumns(namespace: string, columns: string[]): Promise<void>;
 }
 
 export interface MALDataDuplicationRepositoryGetOptions {

--- a/src/domain/mal-dataset-duplication/usecases/GetApprovalAndDuplicateColumnsUseCase.ts
+++ b/src/domain/mal-dataset-duplication/usecases/GetApprovalAndDuplicateColumnsUseCase.ts
@@ -4,7 +4,7 @@ import { MALDataDuplicationRepository } from "../repositories/MALDataDuplication
 export class GetApprovalAndDuplicateColumnsUseCase implements UseCase {
     constructor(private approvalRepository: MALDataDuplicationRepository) {}
 
-    execute(): Promise<string[]> {
-        return this.approvalRepository.getColumns();
+    execute(namespace: string): Promise<string[]> {
+        return this.approvalRepository.getColumns(namespace);
     }
 }

--- a/src/domain/mal-dataset-duplication/usecases/SaveApprovalDuplicateColumnsUseCase.ts
+++ b/src/domain/mal-dataset-duplication/usecases/SaveApprovalDuplicateColumnsUseCase.ts
@@ -4,7 +4,7 @@ import { MALDataDuplicationRepository } from "../repositories/MALDataDuplication
 export class SaveApprovalAndDuplicateColumnsUseCase implements UseCase {
     constructor(private approvalRepository: MALDataDuplicationRepository) {}
 
-    execute(columns: string[]): Promise<void> {
-        return this.approvalRepository.saveColumns(columns);
+    execute(namespace: string, columns: string[]): Promise<void> {
+        return this.approvalRepository.saveColumns(namespace, columns);
     }
 }

--- a/src/webapp/reports/mal-dataset-duplication/DataDifferencesList.tsx
+++ b/src/webapp/reports/mal-dataset-duplication/DataDifferencesList.tsx
@@ -9,6 +9,7 @@ import {
 } from "@eyeseetea/d2-ui-components";
 import _ from "lodash";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { Namespaces } from "../../../data/clients/storage/Namespaces";
 import { parseDataDiffItemId } from "../../../domain/mal-dataset-duplication/entities/DataDiffItem";
 import i18n from "../../../locales";
 import { useAppContext } from "../../contexts/app-context";
@@ -30,8 +31,8 @@ export const DataDifferencesList: React.FC<DataDifferencesListProps> = ({ select
             columns: [
                 { name: "dataelement", text: i18n.t("Data Element"), sortable: true },
                 { name: "value", text: i18n.t("Value entered"), sortable: false },
-                { name: "apvdvalue", text: i18n.t("Approved value"), sortable: false },
                 { name: "comment", text: i18n.t("Comment"), sortable: false },
+                { name: "apvdvalue", text: i18n.t("Approved value"), sortable: false },
                 { name: "apvdcomment", text: i18n.t("Approved value comment"), sortable: false },
             ],
             actions: [],
@@ -73,7 +74,7 @@ export const DataDifferencesList: React.FC<DataDifferencesListProps> = ({ select
 
     const saveReorderedColumns = useCallback(
         async (columnKeys: Array<keyof DataDiffViewModel>) => {
-            await compositionRoot.dataDuplicate.saveColumns(columnKeys);
+            await compositionRoot.dataDuplicate.saveColumns(Namespaces.MAL_DIFF_STATUS_USER_COLUMNS, columnKeys);
         },
         [compositionRoot]
     );
@@ -93,7 +94,16 @@ export const DataDifferencesList: React.FC<DataDifferencesListProps> = ({ select
     }, [tableProps.columns, visibleColumns]);
 
     useEffect(() => {
-        compositionRoot.dataDuplicate.getColumns().then(columns => setVisibleColumns(columns));
+        compositionRoot.dataDuplicate.getColumns(Namespaces.MAL_DIFF_STATUS_USER_COLUMNS).then((columns) => {
+            columns = columns.length ? columns : [
+                "dataelement",
+                "value",
+                "comment",
+                "apvdvalue",
+                "apvdcomment"
+            ];
+            setVisibleColumns(columns);
+        });
     }, [compositionRoot]);
 
     return (

--- a/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
@@ -282,10 +282,10 @@ export const DataApprovalList: React.FC = React.memo(() => {
                 "period",
                 "completed",
                 "validated",
-                "modificationCount",
                 "lastUpdatedValue",
                 "lastDateOfSubmission",
-                "lastDateOfApproval"
+                "lastDateOfApproval",
+                "modificationCount"
             ];
             setVisibleColumns(columns);
         });

--- a/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-dataset-duplication/data-approval-list/DataApprovalList.tsx
@@ -31,6 +31,7 @@ import { DataApprovalViewModel, getDataApprovalViews } from "../DataApprovalView
 import { DataSetsFilter, Filters } from "./Filters";
 import { DataDifferencesList } from "../DataDifferencesList";
 import { PlaylistAddCheck, ThumbUp } from "@material-ui/icons";
+import { Namespaces } from "../../../../data/clients/storage/Namespaces";
 
 export const DataApprovalList: React.FC = React.memo(() => {
     const { compositionRoot, config } = useAppContext();
@@ -65,9 +66,8 @@ export const DataApprovalList: React.FC = React.memo(() => {
             columns: [
                 { name: "orgUnit", text: i18n.t("Organisation unit"), sortable: true },
                 { name: "period", text: i18n.t("Period"), sortable: true },
-                { name: "dataSet", text: i18n.t("Data set"), sortable: true },
+                { name: "dataSet", text: i18n.t("Data set"), sortable: true, hidden: true },
                 { name: "attribute", text: i18n.t("Attribute"), sortable: true, hidden: true },
-                { name: "modificationCount", text: i18n.t("Modification Count"), sortable: true },
                 {
                     name: "completed",
                     text: i18n.t("Completion status"),
@@ -81,6 +81,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                     getValue: row =>
                         row.validated ? "Submitted" : row.completed ? "Ready for submission" : "Not completed",
                 },
+                { name: "modificationCount", text: i18n.t("Modification Count"), sortable: true },
                 {
                     name: "lastUpdatedValue",
                     text: i18n.t("Last modification date"),
@@ -122,7 +123,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: (rows: DataApprovalViewModel[]) => {return _.every(rows, row => row.completed === false 
+                    isActive: (rows: DataApprovalViewModel[]) => { return _.every(rows, row => row.completed === false 
                         && row.lastUpdatedValue) 
                         && (isMalApprover || isMalAdmin)
                     },
@@ -157,8 +158,8 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: (rows: DataApprovalViewModel[]) => {return _.every(rows, row => row.validated === false 
-                        && row.lastUpdatedValue) 
+                    isActive: (rows: DataApprovalViewModel[]) => { return _.every(rows, row => row.validated === false 
+                        && row.lastUpdatedValue)
                         && (isMalApprover || isMalAdmin)
                     },
                 },
@@ -244,7 +245,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
         async (columnKeys: Array<keyof DataApprovalViewModel>) => {
             if (!visibleColumns) return;
 
-            await compositionRoot.dataDuplicate.saveColumns(columnKeys);
+            await compositionRoot.dataDuplicate.saveColumns(Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS, columnKeys);
         },
         [compositionRoot, visibleColumns]
     );
@@ -275,7 +276,19 @@ export const DataApprovalList: React.FC = React.memo(() => {
     const filterOptions = React.useMemo(() => getFilterOptions(config, selectablePeriods), [config, selectablePeriods]);
 
     useEffect(() => {
-        compositionRoot.dataDuplicate.getColumns().then(columns => setVisibleColumns(columns));
+        compositionRoot.dataDuplicate.getColumns(Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS).then((columns) => {
+            columns = columns.length ? columns : [
+                "orgUnit",
+                "period",
+                "completed",
+                "validated",
+                "modificationCount",
+                "lastUpdatedValue",
+                "lastDateOfSubmission",
+                "lastDateOfApproval"
+            ];
+            setVisibleColumns(columns);
+        });
     }, [compositionRoot]);
 
     return (


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [Selected columns are in blank right after compiling the report](https://app.clickup.com/t/2y2k20k)

### :memo: Implementation

Add columns fallback value.
Fix DataDifferencesList.tsx overwriting DataApprovalList.tsx columns namespace.

### :fire: Notes to the tester

This issue was hard to replicate sometimes.
For what i gathered the issue was a race condition to set the `visibleColumns` useState and write the namespace caused by this code:
```
useEffect(() => {
        compositionRoot.dataDuplicate.getColumns().then(columns => setVisibleColumns(columns));
    }, [compositionRoot]);
```
It would get an empty array on startup because the namespace was empty on that moment (`getColumns()`), thus setting `visibleColumns` to an empty array and overwriting the namespace after it's set with the correct values.
