### PR TITLE
In the Check differences list, we have to order the DEs following the order in the sections of the dataset

### DIFF
--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -20,6 +20,8 @@ import { GetApprovalAndDuplicateColumnsUseCase } from "./domain/mal-dataset-dupl
 import { GetDataSetsDuplicationUseCase } from "./domain/mal-dataset-duplication/usecases/GetDataSetsDuplicationUseCaseOptions";
 import { SaveApprovalAndDuplicateColumnsUseCase } from "./domain/mal-dataset-duplication/usecases/SaveApprovalDuplicateColumnsUseCase";
 import { SaveDataSetsDuplicationUseCase } from "./domain/mal-dataset-duplication/usecases/SaveDataSetsDuplicationUseCase";
+import { GetSortOrderUseCase } from "./domain/mal-dataset-duplication/usecases/GetSortOrderUseCase";
+import { GenerateSortOrderUseCase } from "./domain/mal-dataset-duplication/usecases/GenerateSortOrderUseCase";
 import { D2Api } from "./types/d2-api";
 import { GetDataDiffUseCase } from "./domain/mal-dataset-duplication/usecases/GetDataDiffUseCase";
 
@@ -54,6 +56,8 @@ export function getCompositionRoot(api: D2Api) {
             getColumns: new GetApprovalAndDuplicateColumnsUseCase(dataDuplicationRepository),
             saveColumns: new SaveApprovalAndDuplicateColumnsUseCase(dataDuplicationRepository),
             updateStatus: new UpdateStatusAndDuplicateUseCase(dataDuplicationRepository),
+            getSortOrder: new GetSortOrderUseCase(dataDuplicationRepository),
+            generateSortOrder: new GenerateSortOrderUseCase(dataDuplicationRepository),
         }),
         orgUnits: getExecute({
             get: new GetOrgUnitsUseCase(orgUnitsRepository),

--- a/src/data/MALDataDuplicationDefaultRepository.ts
+++ b/src/data/MALDataDuplicationDefaultRepository.ts
@@ -18,6 +18,7 @@ import { CsvWriterDataSource } from "./CsvWriterCsvDataSource";
 import { Dhis2SqlViews, SqlViewGetData } from "./Dhis2SqlViews";
 import { Instance } from "./entities/Instance";
 import { downloadFile } from "./utils/download-file";
+import { Namespaces } from "./clients/storage/Namespaces";
 
 export interface Pagination {
     page: number;
@@ -166,7 +167,17 @@ export class MALDataDuplicationDefaultRepository implements MALDataDuplicationRe
             })
         );
 
-        return paginate(items, paging_to_download);
+        const dataElementOrderArray = await this.getSortOrder();
+
+        const sortedItems = items.sort((a, b) => {
+            if (a.dataelement && b.dataelement) {
+                return dataElementOrderArray.indexOf(a.dataelement) - dataElementOrderArray.indexOf(b.dataelement);
+            } else {
+                return 0;
+            }
+        });
+
+        return paginate(sortedItems, paging_to_download);
     }
 
     async get(options: MALDataDuplicationRepositoryGetOptions): Promise<PaginatedObjects<DataDuplicationItem>> {

--- a/src/data/clients/storage/Namespaces.ts
+++ b/src/data/clients/storage/Namespaces.ts
@@ -7,10 +7,12 @@ export const Namespaces = {
     NHWA_APPROVAL_STATUS_USER_COLUMNS: "nhwa-approval-status-user-columns",
     MAL_APPROVAL_STATUS_USER_COLUMNS: "mal-approval-status-user-columns",
     MAL_DIFF_STATUS_USER_COLUMNS: "mal-diff-status-user-columns",
+    MAL_DIFF_NAMES_SORT_ORDER: "mal-diff-names-sort-order",
 };
 
 export const NamespaceProperties: Record<Namespace, string[]> = {
     [Namespaces.NHWA_APPROVAL_STATUS_USER_COLUMNS]: [],
     [Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS]: [],
     [Namespaces.MAL_DIFF_STATUS_USER_COLUMNS]: [],
+    [Namespaces.MAL_DIFF_NAMES_SORT_ORDER]: [],
 };

--- a/src/domain/mal-dataset-duplication/repositories/MALDataDuplicationRepository.ts
+++ b/src/domain/mal-dataset-duplication/repositories/MALDataDuplicationRepository.ts
@@ -15,6 +15,8 @@ export interface MALDataDuplicationRepository {
     unapprove(dataSets: DataDuplicationItemIdentifier[]): Promise<boolean>;
     getColumns(namespace: string): Promise<string[]>;
     saveColumns(namespace: string, columns: string[]): Promise<void>;
+    getSortOrder(): Promise<string[]>;
+    generateSortOrder(): Promise<void>;
 }
 
 export interface MALDataDuplicationRepositoryGetOptions {

--- a/src/domain/mal-dataset-duplication/usecases/GenerateSortOrderUseCase.ts
+++ b/src/domain/mal-dataset-duplication/usecases/GenerateSortOrderUseCase.ts
@@ -1,0 +1,10 @@
+import { UseCase } from "../../../compositionRoot";
+import { MALDataDuplicationRepository } from "../repositories/MALDataDuplicationRepository";
+
+export class GenerateSortOrderUseCase implements UseCase {
+    constructor(private approvalRepository: MALDataDuplicationRepository) { }
+
+    execute(): Promise<void> {
+        return this.approvalRepository.generateSortOrder();
+    }
+}

--- a/src/domain/mal-dataset-duplication/usecases/GetSortOrderUseCase.ts
+++ b/src/domain/mal-dataset-duplication/usecases/GetSortOrderUseCase.ts
@@ -1,0 +1,10 @@
+import { UseCase } from "../../../compositionRoot";
+import { MALDataDuplicationRepository } from "../repositories/MALDataDuplicationRepository";
+
+export class GetSortOrderUseCase implements UseCase {
+    constructor(private approvalRepository: MALDataDuplicationRepository) { }
+
+    execute(): Promise<string[]> {
+        return this.approvalRepository.getSortOrder();
+    }
+}

--- a/src/webapp/reports/mal-dataset-duplication/MALDataApprovalStatusReport.tsx
+++ b/src/webapp/reports/mal-dataset-duplication/MALDataApprovalStatusReport.tsx
@@ -1,9 +1,16 @@
 import { Typography, makeStyles } from "@material-ui/core";
+import { useEffect } from "react";
 import i18n from "../../../locales";
+import { useAppContext } from "../../contexts/app-context";
 import { DataApprovalList } from "./data-approval-list/DataApprovalList";
 
 const MALDataApprovalStatusReport: React.FC = () => {
     const classes = useStyles();
+    const { compositionRoot } = useAppContext();
+
+    useEffect(() => {
+        compositionRoot.dataDuplicate.generateSortOrder()
+    });
 
     return (
         <div className={classes.wrapper}>


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** [In the Check differences list, we have to order the DEs following the order in the sections of the dataset](https://app.clickup.com/t/2ykj52h)

### :memo: Implementation

The sort order array is stored to `/api/userDataStore/d2-reports/mal-diff-names-sort-order`.

Maybe we could point this branch to "feature/refactor_mal_data_approval" after the functional test, i can take care of the merge, for now its mostly folder structure changes and import routes.