### PR TITLE
Mal report do not use constants, fixing it

### DIFF
--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -25,7 +25,7 @@ const base = {
         dataSets: { namePrefix: "MAL - WMR Form", nameExcluded: /-APVD$/ },
 
         sqlViewNames: [SQL_VIEW_DATA_DUPLICATION_NAME, SQL_VIEW_MAL_METADATA_NAME, SQL_VIEW_MAL_DIFF_NAME],
-        constantCode: "NHWA_COMMENTS",
+        constantCode: "",
         approvalWorkflows: { namePrefix: "MAL" },
     },
 };
@@ -52,25 +52,41 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             return { ...acc, [sqlView.name]: sqlView };
         }, {});
 
-        const constant = getNth(constants, 0, `Missing constant: ${base[this.type].constantCode}`);
         const currentUser = await this.getCurrentUser();
         const pairedDataElements = getPairedMapping(filteredDataSets);
         const orgUnitList = getPairedOrgunitsMapping(filteredDataSets);
-        const constantData = JSON.parse(constant.description || "{}") as Constant;
-        const { sections, sectionsByDataSet } = getSectionsInfo(constantData);
         const currentYear = new Date().getFullYear();
+        if  (base[this.type].constantCode !== ""){
+            const constant = getNth(constants, 0, `Missing constant: ${base[this.type].constantCode}`);
+            const constantData = JSON.parse(constant.description || "{}") as Constant;
+            const { sections, sectionsByDataSet } = getSectionsInfo(constantData);
 
-        return {
-            dataSets: keyById(filteredDataSets),
-            currentUser,
-            sqlViews,
-            pairedDataElementsByDataSet: pairedDataElements,
-            orgUnits: orgUnitList,
-            sections: keyById(sections),
-            sectionsByDataSet,
-            years: _.range(currentYear - 10, currentYear + 1).map(n => n.toString()),
-            approvalWorkflow: dataApprovalWorkflows,
-        };
+            return {
+                dataSets: keyById(filteredDataSets),
+                currentUser,
+                sqlViews,
+                pairedDataElementsByDataSet: pairedDataElements,
+                orgUnits: orgUnitList,
+                sections: keyById(sections),
+                sectionsByDataSet,
+                years: _.range(currentYear - 10, currentYear + 1).map(n => n.toString()),
+                approvalWorkflow: dataApprovalWorkflows,
+            };
+        }else{
+
+            return {
+                dataSets: keyById(filteredDataSets),
+                currentUser,
+                sqlViews,
+                pairedDataElementsByDataSet: pairedDataElements,
+                orgUnits: orgUnitList,
+                sections: undefined,
+                sectionsByDataSet: undefined,
+                years: _.range(currentYear - 10, currentYear + 1).map(n => n.toString()),
+                approvalWorkflow: dataApprovalWorkflows,
+            };
+
+        }
     }
 
     getMetadata() {

--- a/src/domain/common/entities/Config.ts
+++ b/src/domain/common/entities/Config.ts
@@ -5,7 +5,7 @@ import { User } from "./User";
 
 export interface Config {
     dataSets: Record<Id, NamedRef>;
-    sections: Record<Id, NamedRef>;
+    sections: Record<Id, NamedRef> | undefined;
     currentUser: User;
     sqlViews: Record<string, NamedRef>;
     pairedDataElementsByDataSet: {
@@ -13,8 +13,8 @@ export interface Config {
     };
     orgUnits: string[];
     sectionsByDataSet: {
-        [dataSetId: string]: NamedRef[];
-    };
+        [dataSetId: string]: NamedRef[] 
+    }| undefined;
     years: string[];
     approvalWorkflow: NamedRef[];
 }

--- a/src/webapp/reports/nhwa-comments/DataCommentsViewModel.ts
+++ b/src/webapp/reports/nhwa-comments/DataCommentsViewModel.ts
@@ -20,18 +20,36 @@ export interface DataCommentsViewModel {
 
 export function getDataCommentsViews(config: Config, dataValues: DataCommentsItem[]): DataCommentsViewModel[] {
     return dataValues.map(dataValue => {
-        return {
-            id: getDataCommentsItemId(dataValue),
-            period: dataValue.period,
-            orgUnit: dataValue.orgUnit.name,
-            dataSet: dataValue.dataSet.name,
-            dataElement: dataValue.dataElement.name,
-            section: config.sections[dataValue.section]?.name || "-",
-            categoryOptionCombo: dataValue.categoryOptionCombo.name,
-            value: dataValue.value,
-            comment: dataValue.comment || "",
-            lastUpdated: dataValue.lastUpdated.toISOString(),
-            storedBy: dataValue.storedBy,
-        };
+        if(config.sections !== undefined && config.sections[dataValue.section] !== undefined){
+            return {
+                id: getDataCommentsItemId(dataValue),
+                period: dataValue.period,
+                orgUnit: dataValue.orgUnit.name,
+                dataSet: dataValue.dataSet.name,
+                dataElement: dataValue.dataElement.name, 
+                // eslint-disable-next-line
+                section: config.sections[dataValue.section]!.name || "-",
+                categoryOptionCombo: dataValue.categoryOptionCombo.name,
+                value: dataValue.value,
+                comment: dataValue.comment || "",
+                lastUpdated: dataValue.lastUpdated.toISOString(),
+                storedBy: dataValue.storedBy,
+            };
+        }else{
+            return {
+                id: getDataCommentsItemId(dataValue),
+                period: dataValue.period,
+                orgUnit: dataValue.orgUnit.name,
+                dataSet: dataValue.dataSet.name,
+                dataElement: dataValue.dataElement.name,
+                section: "-",
+                categoryOptionCombo: dataValue.categoryOptionCombo.name,
+                value: dataValue.value,
+                comment: dataValue.comment || "",
+                lastUpdated: dataValue.lastUpdated.toISOString(),
+                storedBy: dataValue.storedBy,
+            };
+
+        }
     });
 }


### PR DESCRIPTION
### :pushpin: References
I have to add a " // eslint-disable-next-line" in the third file to move forward but we should refactor it.

I have added a if for checking if the sections are undefined for the case of the MAL report, but not sure why the lint was showing it as error the config.sections[dataValue.section] variable, but its filtered in the if and never will be undefined in that line.

-   **Issue:** Closes #?

### :memo: Implementation
Mal report not use any constant but a nwha was requested to the users, if you wasn't admin you didn't load the report.


### :art: Screenshots

### :fire: Notes to the tester
