### PR TITLE
feat: show no datasets when nothing submitted adn do not show anythin…

### DIFF
--- a/src/data/reports/glass-data-submission/GLASSDataSubmissionDefaultRepository.ts
+++ b/src/data/reports/glass-data-submission/GLASSDataSubmissionDefaultRepository.ts
@@ -68,11 +68,32 @@ export class GLASSDataSubmissionDefaultRepository implements GLASSDataSubmission
             const submissionStatus = statusItems.find(item => item.value === object.status)?.text ?? "";
 
             const uploadStatus = uploads.filter(upload => upload.dataSubmission === object.id).map(item => item.status);
-            const uploadedDatasets = uploadStatus.filter(item => item === "UPLOADED").length;
             const completedDatasets = uploadStatus.filter(item => item === "COMPLETED").length;
-            const importedDatasets = uploadStatus.filter(item => item === "IMPORTED").length;
             const validatedDatasets = uploadStatus.filter(item => item === "VALIDATED").length;
-            const dataSetsUploaded = `${uploadedDatasets} uploaded, ${completedDatasets} completed, ${importedDatasets} imported, ${validatedDatasets} validated`;
+            const importedDatasets = uploadStatus.filter(item => item === "IMPORTED").length;
+            const uploadedDatasets = uploadStatus.filter(item => item === "UPLOADED").length;
+            
+            let dataSetsUploaded = "";
+            if (completedDatasets > 0) {
+              dataSetsUploaded += `${completedDatasets} completed, `;
+            }
+            if (validatedDatasets > 0) {
+              dataSetsUploaded += `${validatedDatasets} validated, `;
+            }
+            if (importedDatasets > 0) {
+              dataSetsUploaded += `${importedDatasets} imported, `;
+            }
+            if (uploadedDatasets > 0) {
+              dataSetsUploaded += `${uploadedDatasets} uploaded, `;
+            }
+            
+            // Remove trailing comma and space if any
+            dataSetsUploaded = dataSetsUploaded.replace(/,\s*$/, "");
+
+            // Show "No datasets" if all variables are 0
+            if (dataSetsUploaded === "") {
+                dataSetsUploaded = "No datasets";
+            }
 
             return {
                 ...object,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** No issue

### :memo: Implementation
This code snippet counts the number of occurrences of specific statuses in an array called uploadStatus. The statuses are "COMPLETED", "VALIDATED", "IMPORTED", and "UPLOADED". For each status, it filters the array to keep only the elements matching the status and calculates the length of the resulting array. Then, it constructs a string called dataSetsUploaded that describes the counts of each status. The string only includes the counts that are greater than 0. If none of the counts are greater than 0, the dataSetsUploaded string is set to "No datasets".

### :art: Screenshots
![screenshots_1680811288_2201_06042023_1026x701](https://user-images.githubusercontent.com/10931645/230482321-8153280e-c1e2-4931-b294-edfa057bf332.png)

### :fire: Notes to the tester
Nothing in particular apart form having one file in each status and some data-submission with no submitted file