### PR TITLE
fix: glass pointing to nhwa datasets

### DIFF
--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -34,6 +34,12 @@ const base = {
         constantCode: "",
         approvalWorkflows: { namePrefix: "MAL" },
     },
+    glass: {
+        dataSets: { namePrefix: "AMR", nameExcluded: /-APVD$/ },
+        sqlViewNames: [],
+        constantCode: "",
+        approvalWorkflows: { namePrefix: "AMR" },
+    },
 };
 
 export class Dhis2ConfigRepository implements ConfigRepository {

--- a/src/domain/common/entities/ReportType.ts
+++ b/src/domain/common/entities/ReportType.ts
@@ -1,1 +1,1 @@
-export type ReportType = "nhwa" | "mal";
+export type ReportType = "nhwa" | "mal" | "glass";

--- a/src/webapp/utils/reportType.ts
+++ b/src/webapp/utils/reportType.ts
@@ -3,5 +3,5 @@ import { ReportType } from "../../domain/common/entities/ReportType";
 export function getReportType(): ReportType {
     const report = process.env.REACT_APP_REPORT_VARIANT || "";
 
-    return report === "mal-approval-status" ? "mal" : "nhwa";
+    return report === "mal-approval-status" ? "mal" : report === "glass-submission" ? "glass" : "nhwa";
 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/860qfj89n

### :memo: Implementation
- Add GLASS report type to DHIS2 config repository to prevent GLASS submission report from pointing to NHWA datasets. 

### :art: Screenshots

### :fire: Notes to the tester
