### PR TITLE
Fix: mal approval revoke error

### DIFF
--- a/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
+++ b/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
@@ -321,7 +321,7 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
             }));
 
             const dateResponse = await this.api.post<any>("/dataValueSets.json", {}, { dataValues }).getData();
-            if (dateResponse.status !== "SUCCESS") throw new Error("Error when posting Submission date");
+            if (dateResponse.response.status !== "SUCCESS") throw new Error("Error when posting Submission date");
 
             let completeCheckResponses: completeCheckresponseType = await promiseMap(dataSets, async approval =>
                 this.api
@@ -356,7 +356,7 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
                 this.api
                     .post<any>(
                         "/dataApprovals",
-                        { wf: approval.workflow, pe: approval.period, ou: approval.orgUnit },
+                        { ds: approval.dataSet, pe: approval.period, ou: approval.orgUnit },
                         {}
                     )
                     .getData()

--- a/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
+++ b/src/data/reports/mal-data-approval/MalDataApprovalDefaultRepository.ts
@@ -304,9 +304,11 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
         }));
 
         try {
-            const response = await this.api
-                .post<any>("/completeDataSetRegistrations", {}, { completeDataSetRegistrations })
-                .getData();
+            const response = (
+                await this.api
+                    .post<any>("/completeDataSetRegistrations", {}, { completeDataSetRegistrations })
+                    .getData()
+            ).response;
 
             return response.status === "SUCCESS";
         } catch (error: any) {
@@ -354,8 +356,7 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
                 _.isEqual(_.omit(value, ["workflow"]), othervalue)
             );
 
-            const completeResponse =
-                Object.keys(dataSetsToComplete).length !== 0 ? await this.complete(dataSetsToComplete) : true;
+            const completeResponse = dataSetsToComplete.length !== 0 ? await this.complete(dataSetsToComplete) : true;
 
             const response = await promiseMap(dataSets, async approval =>
                 this.api
@@ -605,7 +606,7 @@ export class MalDataApprovalDefaultRepository implements MalDataApprovalReposito
         try {
             const response = await promiseMap(dataSets, async approval =>
                 this.api
-                    .delete<any>("/dataApprovals", { wf: approval.workflow, pe: approval.period, ou: approval.orgUnit })
+                    .delete<any>("/dataApprovals", { ds: approval.dataSet, pe: approval.period, ou: approval.orgUnit })
                     .getData()
             );
 

--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -9,6 +9,7 @@ export interface MalDataApprovalItem {
     approvalWorkflow: string | undefined;
     completed: boolean;
     validated: boolean;
+    approved?: boolean;
     lastUpdatedValue: string | undefined;
     lastDateOfSubmission: string | undefined;
     lastDateOfApproval: string | undefined;

--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -21,7 +21,7 @@ export interface MalDataApprovalItemIdentifier {
     dataSet: string;
     orgUnit: string;
     period: string;
-    workflow: string;
+    workflow: string | undefined;
 }
 
 export interface Monitoring {
@@ -46,7 +46,7 @@ export function getDataDuplicationItemMonitoringValue(dataSet: MalDataApprovalIt
 
 export function parseDataDuplicationItemId(string: string): MalDataApprovalItemIdentifier | undefined {
     const [dataSet, workflow, period, orgUnit] = string.split("-");
-    if (!dataSet || !workflow || !period || !orgUnit) return undefined;
+    if (!dataSet || !period || !orgUnit) return undefined;
 
     return { dataSet, workflow, period, orgUnit };
 }

--- a/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
+++ b/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
@@ -24,6 +24,7 @@ export interface DataApprovalViewModel {
     lastDateOfApproval: Date | undefined;
     modificationCount: string | undefined;
     monitoring: boolean | undefined;
+    approved: boolean | undefined;
 }
 
 export function getDataApprovalViews(
@@ -53,6 +54,7 @@ export function getDataApprovalViews(
                 : undefined,
             modificationCount: item.modificationCount,
             monitoring: getDataDuplicationItemMonitoringValue(item, monitoring),
+            approved: item.approved,
         };
     });
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -209,7 +209,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: rows => _.every(rows, row => row.validated === true),
+                    isActive: rows => _.every(rows, row => row.approved === true),
                 },
                 {
                     name: "approve",

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -189,10 +189,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                         reload();
                     },
                     isActive: (rows: DataApprovalViewModel[]) => {
-                        return (
-                            _.every(rows, row => row.validated === false && row.lastUpdatedValue) &&
-                            (isMalApprover || isMalAdmin)
-                        );
+                        return _.every(rows, row => row.approved === false) && (isMalApprover || isMalAdmin);
                     },
                 },
                 {

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -273,7 +273,10 @@ export const DataApprovalList: React.FC = React.memo(() => {
                         reload();
                     },
                     isActive: (rows: DataApprovalViewModel[]) => {
-                        return _.every(rows, row => row.approved === false) && (isMalApprover || isMalAdmin);
+                        return (
+                            _.every(rows, row => row.approved === false && row.lastUpdatedValue) &&
+                            (isMalApprover || isMalAdmin)
+                        );
                     },
                 },
                 {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cutw7d

### :memo: Implementation
**Problem**: The `revoke` action is visible for row items that are "unapproved". It should only be visible when an item is "approved"  

**Fix**: Added a new property: "approved" that stores the approval value gotten from `\dataApprovals` and set the `revoke` and `submit` action visibilities based on this new "approved" value. 

### :art: Screenshots
https://github.com/EyeSeeTea/d2-reports/assets/37223065/630df28d-a040-4030-bfb8-0d0857e6f7ff


### :fire: Notes to the tester
`REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/`
`REACT_APP_REPORT_VARIANT=mal-approval-status`