### PR TITLE
Feat/adapt monitoring datastore

### DIFF
--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -56,6 +56,7 @@ import { GetSummaryMortalityUseCase } from "./domain/reports/csy-summary-mortali
 import { SaveSummaryMortalityUseCase } from "./domain/reports/csy-summary-mortality/usecases/SaveSummaryUseCase";
 import { CSYAuditTraumaDefaultRepository } from "./data/reports/csy-audit-trauma/CSYAuditTraumaDefaultRepository";
 import { GetEARDataSubmissionUseCase } from "./domain/reports/glass-data-submission/usecases/GetEARDataSubmissionUseCase";
+import { GetMalCountryCodesUseCase } from "./domain/reports/mal-data-approval/usecases/GetMalCountryCodesUseCase";
 
 export function getCompositionRoot(api: D2Api) {
     const configRepository = new Dhis2ConfigRepository(api, getReportType());
@@ -90,6 +91,7 @@ export function getCompositionRoot(api: D2Api) {
         malDataApproval: getExecute({
             get: new GetMalDataSetsUseCase(dataDuplicationRepository),
             getDiff: new GetMalDataDiffUseCase(dataDuplicationRepository),
+            getCountryCodes: new GetMalCountryCodesUseCase(dataDuplicationRepository),
             save: new SaveMalDataSetsUseCase(dataDuplicationRepository),
             getColumns: new GetMalDataApprovalColumnsUseCase(dataDuplicationRepository),
             saveColumns: new SaveMalDataApprovalColumnsUseCase(dataDuplicationRepository),

--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -51,15 +51,32 @@ export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
     ].join("-");
 }
 
+// export function getDataDuplicationItemMonitoringValue(dataSet: MalDataApprovalItem, monitoring: Monitoring[]): boolean {
+//     const monitoringValue =
+//         monitoring.find(
+//             monitoringValue =>
+//                 monitoringValue.orgUnit === dataSet.orgUnitUid && monitoringValue.period === dataSet.period
+//         )?.monitoring ?? false;
+
+//     return monitoringValue;
+// }
+
 export function getDataDuplicationItemMonitoringValue(
     dataSet: MalDataApprovalItem,
     dataSetName: string,
-    monitoring: MonitoringValue
+    monitoring: MonitoringValue | Monitoring[]
 ): boolean {
-    const monitoringArray = monitoring["dataSets"]?.[dataSetName]?.monitoring;
-    const monitoringValue = !!_.find(monitoringArray, { orgUnit: dataSet.orgUnitCode, period: dataSet.period });
-
-    return monitoringValue;
+    if (_.isArray(monitoring)) {
+        return (
+            monitoring.find(
+                monitoringValue =>
+                    monitoringValue.orgUnit === dataSet.orgUnitUid && monitoringValue.period === dataSet.period
+            )?.monitoring ?? false
+        );
+    } else {
+        const monitoringArray = monitoring["dataSets"]?.[dataSetName]?.monitoring;
+        return !!_.find(monitoringArray, { orgUnit: dataSet.orgUnitCode, period: dataSet.period });
+    }
 }
 
 export function parseDataDuplicationItemId(string: string): MalDataApprovalItemIdentifier | undefined {

--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -1,8 +1,11 @@
+import _ from "lodash";
+
 export interface MalDataApprovalItem {
     dataSetUid: string;
     dataSet: string;
     orgUnitUid: string;
     orgUnit: string;
+    orgUnitCode: string;
     period: string;
     attribute: string | undefined;
     approvalWorkflowUid: string | undefined;
@@ -19,33 +22,49 @@ export interface MalDataApprovalItem {
 export interface MalDataApprovalItemIdentifier {
     dataSet: string;
     orgUnit: string;
+    orgUnitCode: string | undefined;
     period: string;
-    workflow: string;
+    workflow: string | undefined;
 }
 
 export interface Monitoring {
     orgUnit: string;
     period: string;
-    monitoring: boolean;
+    monitoring?: boolean;
+    enable?: boolean;
 }
+
+export interface CountryCode {
+    id: string;
+    code: string;
+}
+
+export type MonitoringValue = Record<string, Record<string, { monitoring: Monitoring[]; userGroup: string }>>;
 
 export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
-    return [dataSet.dataSetUid, dataSet.approvalWorkflowUid, dataSet.period, dataSet.orgUnitUid].join("-");
+    return [
+        dataSet.dataSetUid,
+        dataSet.approvalWorkflowUid,
+        dataSet.period,
+        dataSet.orgUnitUid,
+        dataSet.orgUnitCode,
+    ].join("-");
 }
 
-export function getDataDuplicationItemMonitoringValue(dataSet: MalDataApprovalItem, monitoring: Monitoring[]): boolean {
-    const monitoringValue =
-        monitoring.find(
-            monitoringValue =>
-                monitoringValue.orgUnit === dataSet.orgUnitUid && monitoringValue.period === dataSet.period
-        )?.monitoring ?? false;
+export function getDataDuplicationItemMonitoringValue(
+    dataSet: MalDataApprovalItem,
+    dataSetName: string,
+    monitoring: MonitoringValue
+): boolean {
+    const monitoringArray = monitoring["dataSets"]?.[dataSetName]?.monitoring;
+    const monitoringValue = !!_.find(monitoringArray, { orgUnit: dataSet.orgUnitCode, period: dataSet.period });
 
     return monitoringValue;
 }
 
 export function parseDataDuplicationItemId(string: string): MalDataApprovalItemIdentifier | undefined {
-    const [dataSet, workflow, period, orgUnit] = string.split("-");
-    if (!dataSet || !workflow || !period || !orgUnit) return undefined;
+    const [dataSet, workflow, period, orgUnit, orgUnitCode] = string.split("-");
+    if (!dataSet || !period || !orgUnit || !orgUnitCode) return undefined;
 
-    return { dataSet, workflow, period, orgUnit };
+    return { dataSet, workflow, period, orgUnit, orgUnitCode };
 }

--- a/src/domain/reports/mal-data-approval/repositories/MalDataApprovalRepository.ts
+++ b/src/domain/reports/mal-data-approval/repositories/MalDataApprovalRepository.ts
@@ -2,12 +2,13 @@ import { Id } from "../../../common/entities/Base";
 import { Config } from "../../../common/entities/Config";
 import { PaginatedObjects, Paging, Sorting } from "../../../common/entities/PaginatedObjects";
 import { DataDiffItem } from "../entities/DataDiffItem";
-import { MalDataApprovalItem, MalDataApprovalItemIdentifier, Monitoring } from "../entities/MalDataApprovalItem";
+import { MalDataApprovalItem, MalDataApprovalItemIdentifier, MonitoringValue } from "../entities/MalDataApprovalItem";
 import { DataDiffItemIdentifier } from "../entities/DataDiffItem";
 
 export interface MalDataApprovalRepository {
     get(options: MalDataApprovalOptions): Promise<PaginatedObjects<MalDataApprovalItem>>;
     getDiff(options: MalDataApprovalOptions): Promise<PaginatedObjects<DataDiffItem>>;
+    getCountryCodes(): Promise<{ id: string; code: string }[]>;
     save(filename: string, dataSets: MalDataApprovalItem[]): Promise<void>;
     complete(dataSets: MalDataApprovalItemIdentifier[]): Promise<boolean>;
     approve(dataSets: MalDataApprovalItemIdentifier[]): Promise<boolean>;
@@ -18,8 +19,8 @@ export interface MalDataApprovalRepository {
     unapprove(dataSets: MalDataApprovalItemIdentifier[]): Promise<boolean>;
     getColumns(namespace: string): Promise<string[]>;
     saveColumns(namespace: string, columns: string[]): Promise<void>;
-    getMonitoring(namespace: string): Promise<Monitoring[]>;
-    saveMonitoring(namespace: string, monitoring: Monitoring[]): Promise<void>;
+    getMonitoring(namespace: string): Promise<MonitoringValue>;
+    saveMonitoring(namespace: string, monitoring: MonitoringValue): Promise<void>;
     getSortOrder(): Promise<string[]>;
     generateSortOrder(): Promise<void>;
 }

--- a/src/domain/reports/mal-data-approval/usecases/GetMalCountryCodesUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/GetMalCountryCodesUseCase.ts
@@ -1,0 +1,11 @@
+import { UseCase } from "../../../../compositionRoot";
+import { MalDataApprovalRepository } from "../repositories/MalDataApprovalRepository";
+
+export class GetMalCountryCodesUseCase implements UseCase {
+    constructor(private dataSetRepository: MalDataApprovalRepository) {}
+
+    execute(): Promise<{ id: string; code: string }[]> {
+        // FUTURE: Return a Future-like instead, to allow better error handling and cancellation.
+        return this.dataSetRepository.getCountryCodes();
+    }
+}

--- a/src/domain/reports/mal-data-approval/usecases/GetMonitoringUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/GetMonitoringUseCase.ts
@@ -1,11 +1,11 @@
 import { UseCase } from "../../../../compositionRoot";
-import { Monitoring } from "../entities/MalDataApprovalItem";
+import { MonitoringValue } from "../entities/MalDataApprovalItem";
 import { MalDataApprovalRepository } from "../repositories/MalDataApprovalRepository";
 
 export class GetMonitoringUseCase implements UseCase {
     constructor(private approvalRepository: MalDataApprovalRepository) {}
 
-    execute(namespace: string): Promise<Monitoring[]> {
+    execute(namespace: string): Promise<MonitoringValue> {
         return this.approvalRepository.getMonitoring(namespace);
     }
 }

--- a/src/domain/reports/mal-data-approval/usecases/SaveMonitoringUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/SaveMonitoringUseCase.ts
@@ -1,11 +1,11 @@
 import { UseCase } from "../../../../compositionRoot";
-import { Monitoring } from "../entities/MalDataApprovalItem";
+import { MonitoringValue } from "../entities/MalDataApprovalItem";
 import { MalDataApprovalRepository } from "../repositories/MalDataApprovalRepository";
 
 export class SaveMonitoringUseCase implements UseCase {
     constructor(private approvalRepository: MalDataApprovalRepository) {}
 
-    execute(namespace: string, monitoring: Monitoring[]): Promise<void> {
+    execute(namespace: string, monitoring: MonitoringValue): Promise<void> {
         return this.approvalRepository.saveMonitoring(namespace, monitoring);
     }
 }

--- a/src/domain/reports/mal-data-approval/usecases/UpdateMalApprovalStatusUseCase.ts
+++ b/src/domain/reports/mal-data-approval/usecases/UpdateMalApprovalStatusUseCase.ts
@@ -1,5 +1,5 @@
 import { Namespaces } from "../../../../data/common/clients/storage/Namespaces";
-import { MalDataApprovalItemIdentifier, Monitoring } from "../entities/MalDataApprovalItem";
+import { MalDataApprovalItemIdentifier, MonitoringValue } from "../entities/MalDataApprovalItem";
 import { MalDataApprovalRepository } from "../repositories/MalDataApprovalRepository";
 
 export class UpdateMalApprovalStatusUseCase {
@@ -7,8 +7,9 @@ export class UpdateMalApprovalStatusUseCase {
 
     async execute(
         items: MalDataApprovalItemIdentifier[],
-        action: UpdateAction
-    ): Promise<boolean | Monitoring[] | void> {
+        action: UpdateAction,
+        monitoring?: MonitoringValue
+    ): Promise<boolean | MonitoringValue | void> {
         switch (action) {
             case "complete":
                 return this.approvalRepository.complete(items);
@@ -23,7 +24,7 @@ export class UpdateMalApprovalStatusUseCase {
             case "activate":
                 return this.approvalRepository.getMonitoring(Namespaces.MONITORING);
             case "deactivate":
-                return this.approvalRepository.saveMonitoring(Namespaces.MONITORING, []);
+                return this.approvalRepository.saveMonitoring(Namespaces.MONITORING, monitoring ?? {});
             default:
                 return false;
         }

--- a/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
+++ b/src/webapp/reports/mal-data-approval/DataApprovalViewModel.ts
@@ -3,7 +3,7 @@ import {
     MalDataApprovalItem,
     getDataDuplicationItemId,
     getDataDuplicationItemMonitoringValue,
-    Monitoring,
+    MonitoringValue,
 } from "../../../domain/reports/mal-data-approval/entities/MalDataApprovalItem";
 import { toDate } from "date-fns-tz";
 
@@ -27,9 +27,9 @@ export interface DataApprovalViewModel {
 }
 
 export function getDataApprovalViews(
-    _config: Config,
+    config: Config,
     items: MalDataApprovalItem[],
-    monitoring: Monitoring[]
+    monitoring: MonitoringValue
 ): DataApprovalViewModel[] {
     return items.map(item => {
         return {
@@ -52,7 +52,11 @@ export function getDataApprovalViews(
                 ? toDate(item.lastDateOfApproval, { timeZone: "UTC" })
                 : undefined,
             modificationCount: item.modificationCount,
-            monitoring: getDataDuplicationItemMonitoringValue(item, monitoring),
+            monitoring: getDataDuplicationItemMonitoringValue(
+                item,
+                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
+                monitoring
+            ),
         };
     });
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -21,8 +21,10 @@ import { Config } from "../../../../domain/common/entities/Config";
 import { getOrgUnitIdsFromPaths } from "../../../../domain/common/entities/OrgUnit";
 import { Sorting } from "../../../../domain/common/entities/PaginatedObjects";
 import {
+    CountryCode,
     MalDataApprovalItem,
     Monitoring,
+    MonitoringValue,
     parseDataDuplicationItemId,
 } from "../../../../domain/reports/mal-data-approval/entities/MalDataApprovalItem";
 import i18n from "../../../../locales";
@@ -37,7 +39,7 @@ import { Notifications, NotificationsOff, PlaylistAddCheck, ThumbUp } from "@mat
 import { Namespaces } from "../../../../data/common/clients/storage/Namespaces";
 
 export const DataApprovalList: React.FC = React.memo(() => {
-    const { compositionRoot, config } = useAppContext();
+    const { compositionRoot, config, api } = useAppContext();
     const { currentUser } = config;
     const [isDialogOpen, { enable: openDialog, disable: closeDialog }] = useBooleanState(false);
     const snackbar = useSnackbar();
@@ -71,23 +73,84 @@ export const DataApprovalList: React.FC = React.memo(() => {
             : _.range(currentYear - 5, currentYear).map(n => n.toString());
     }, [oldPeriods]);
 
-    const [monitoring, setMonitoring] = useState<Monitoring[]>([]);
+    const [monitoring, setMonitoring] = useState<MonitoringValue>({});
+    const [countryCodes, setCountryCodes] = useState<CountryCode[]>([]);
+    const [dataNotificationsUserGroup, setDataNotificationsUserGroup] = useState<string>("");
 
     useEffect(() => {
-        async function getMonitoringValues() {
-            compositionRoot.malDataApproval.getMonitoring(Namespaces.MONITORING).then(monitoringValue => {
-                monitoringValue = monitoringValue.length ? monitoringValue : [];
-                setMonitoring(monitoringValue);
-            });
+        async function getMalNotificationsUserGroup() {
+            const { userGroups } = await api
+                .get<{ userGroups: { id: string }[] }>("/userGroups?fields=id&filter=name:eq:MAL_Data%20Notifications")
+                .getData();
+
+            return _.first(userGroups)?.id ?? "";
         }
-        getMonitoringValues();
-    }, [compositionRoot.malDataApproval]);
+        getMalNotificationsUserGroup().then(userGroup => {
+            setDataNotificationsUserGroup(userGroup);
+        });
+
+        compositionRoot.malDataApproval.getMonitoring(Namespaces.MONITORING).then(monitoringValue => {
+            setMonitoring(monitoringValue);
+        });
+    }, [api, compositionRoot.malDataApproval]);
 
     useEffect(() => {
         compositionRoot.malDataApproval.getColumns(Namespaces.MAL_APPROVAL_STATUS_USER_COLUMNS).then(columns => {
             setVisibleColumns(columns);
         });
     }, [compositionRoot]);
+
+    useEffect(() => {
+        compositionRoot.malDataApproval.getCountryCodes().then(countryCodes => {
+            setCountryCodes(countryCodes);
+        });
+    }, [compositionRoot.malDataApproval]);
+
+    const combiner = React.useMemo(
+        () =>
+            (
+                initialMonitoringValues: MonitoringValue | Monitoring[],
+                addedMonitoringValues: Monitoring[],
+                elementType: string,
+                dataSet: string,
+                userGroup: string
+            ): MonitoringValue => {
+                if (!_.isArray(initialMonitoringValues) && initialMonitoringValues) {
+                    const initialMonitoring = initialMonitoringValues[elementType]?.[dataSet]?.monitoring ?? [];
+
+                    const newDataSets = _.merge({}, initialMonitoringValues[elementType], {
+                        [dataSet]: {
+                            monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
+                        },
+                    });
+
+                    return {
+                        ...initialMonitoringValues,
+                        dataSets: newDataSets,
+                    };
+                } else {
+                    const initialMonitoring: Monitoring[] = initialMonitoringValues.map(initialMonitoringValue => {
+                        return {
+                            orgUnit:
+                                countryCodes.find(countryCode => countryCode.id === initialMonitoringValue.orgUnit)
+                                    ?.code ?? initialMonitoringValue.orgUnit,
+                            period: initialMonitoringValue.period,
+                            enable: initialMonitoringValue.monitoring,
+                        };
+                    });
+
+                    return {
+                        [elementType]: {
+                            [dataSet]: {
+                                monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
+                                userGroup,
+                            },
+                        },
+                    };
+                }
+            },
+        [countryCodes]
+    );
 
     const baseConfig: TableConfig<DataApprovalViewModel> = useMemo(
         () => ({
@@ -224,12 +287,19 @@ export const DataApprovalList: React.FC = React.memo(() => {
                             return {
                                 orgUnit: item.orgUnit,
                                 period: item.period,
-                                monitoring: true,
+                                enable: true,
                             };
                         });
+
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combineMonitoringValues(monitoring, monitoringValues)
+                            combiner(
+                                monitoring,
+                                monitoringValues,
+                                "dataSets",
+                                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
+                                dataNotificationsUserGroup
+                            )
                         );
 
                         const result = await compositionRoot.malDataApproval.updateStatus(items, "duplicate");
@@ -250,14 +320,21 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         const monitoringValues = items.map(item => {
                             return {
-                                orgUnit: item.orgUnit,
+                                orgUnit: item.orgUnitCode ?? item.orgUnit,
                                 period: item.period,
-                                monitoring: true,
+                                enable: true,
                             };
                         });
+
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combineMonitoringValues(monitoring, monitoringValues)
+                            combiner(
+                                monitoring,
+                                monitoringValues,
+                                "dataSets",
+                                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
+                                dataNotificationsUserGroup
+                            )
                         );
 
                         reload();
@@ -277,12 +354,19 @@ export const DataApprovalList: React.FC = React.memo(() => {
                             return {
                                 orgUnit: item.orgUnit,
                                 period: item.period,
-                                monitoring: false,
+                                enable: false,
                             };
                         });
+
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combineMonitoringValues(monitoring, monitoringValues)
+                            combiner(
+                                monitoring,
+                                monitoringValues,
+                                "dataSets",
+                                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
+                                dataNotificationsUserGroup
+                            )
                         );
 
                         reload();
@@ -327,13 +411,16 @@ export const DataApprovalList: React.FC = React.memo(() => {
         }),
         [
             compositionRoot.malDataApproval,
-            isMalAdmin,
-            isMalApprover,
-            monitoring,
-            openDialog,
-            reload,
             snackbar,
+            reload,
+            isMalApprover,
+            isMalAdmin,
+            combiner,
+            monitoring,
+            config.dataSets,
+            dataNotificationsUserGroup,
             disableRevoke,
+            openDialog,
             enableRevoke,
         ]
     );
@@ -411,7 +498,6 @@ export const DataApprovalList: React.FC = React.memo(() => {
             );
         });
         const combinedMonitoring = _.union(_.intersection(...combinedMonitoringValues), addedMonitoringValues);
-        setMonitoring(combinedMonitoring);
 
         return _.union(combinedMonitoring);
     }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cv3rb8

### :memo: Implementation
- Added a new MalApprovalItem property: `orgUnitCode`
- Changed getMonitoring and saveMonitoring functions to adapt to new and old monitoringValue formats

### :art: Screenshots

### :fire: Notes to the tester
`REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/`
`REACT_APP_REPORT_VARIANT=mal-approval-status`
