### PR TITLE
fix: fix monitoring object issues

### DIFF
--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -39,7 +39,7 @@ export interface CountryCode {
     code: string;
 }
 
-export type MonitoringValue = Record<string, Record<string, { monitoring: Monitoring[]; userGroup: string }>>;
+export type MonitoringValue = Record<string, Record<string, { monitoring: Monitoring[]; userGroups: string }>>;
 
 export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
     return [
@@ -50,16 +50,6 @@ export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
         dataSet.orgUnitCode,
     ].join("-");
 }
-
-// export function getDataDuplicationItemMonitoringValue(dataSet: MalDataApprovalItem, monitoring: Monitoring[]): boolean {
-//     const monitoringValue =
-//         monitoring.find(
-//             monitoringValue =>
-//                 monitoringValue.orgUnit === dataSet.orgUnitUid && monitoringValue.period === dataSet.period
-//         )?.monitoring ?? false;
-
-//     return monitoringValue;
-// }
 
 export function getDataDuplicationItemMonitoringValue(
     dataSet: MalDataApprovalItem,

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -342,16 +342,6 @@ export const DataApprovalList: React.FC = React.memo(() => {
                             };
                         });
 
-                        console.log({
-                            git: getMonitoringJson(
-                                monitoring,
-                                monitoringValues,
-                                "dataSets",
-                                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
-                                dataNotificationsUserGroup
-                            ),
-                        });
-
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
                             getMonitoringJson(

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -106,7 +106,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
         });
     }, [compositionRoot.malDataApproval]);
 
-    const combiner = React.useMemo(
+    const getMonitoringJson = React.useMemo(
         () =>
             (
                 initialMonitoringValues: MonitoringValue | Monitoring[],
@@ -119,9 +119,25 @@ export const DataApprovalList: React.FC = React.memo(() => {
                     const initialMonitoring = initialMonitoringValues[elementType]?.[dataSet]?.monitoring ?? [];
 
                     const newDataSets = _.merge({}, initialMonitoringValues[elementType], {
-                        [dataSet]: {
-                            monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
-                        },
+                        [dataSet]: _.omit(
+                            {
+                                monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues).map(
+                                    monitoring => {
+                                        return {
+                                            ...monitoring,
+                                            orgUnit:
+                                                monitoring.orgUnit.length > 3
+                                                    ? countryCodes.find(
+                                                          countryCode => countryCode.id === monitoring.orgUnit
+                                                      )?.code
+                                                    : monitoring.orgUnit,
+                                        };
+                                    }
+                                ),
+                                userGroups: userGroup,
+                            },
+                            "userGroup"
+                        ),
                     });
 
                     return {
@@ -143,7 +159,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                         [elementType]: {
                             [dataSet]: {
                                 monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
-                                userGroup,
+                                userGroups: userGroup,
                             },
                         },
                     };
@@ -293,7 +309,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combiner(
+                            getMonitoringJson(
                                 monitoring,
                                 monitoringValues,
                                 "dataSets",
@@ -326,9 +342,19 @@ export const DataApprovalList: React.FC = React.memo(() => {
                             };
                         });
 
+                        console.log({
+                            git: getMonitoringJson(
+                                monitoring,
+                                monitoringValues,
+                                "dataSets",
+                                config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
+                                dataNotificationsUserGroup
+                            ),
+                        });
+
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combiner(
+                            getMonitoringJson(
                                 monitoring,
                                 monitoringValues,
                                 "dataSets",
@@ -352,7 +378,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         const monitoringValues = items.map(item => {
                             return {
-                                orgUnit: item.orgUnit,
+                                orgUnit: item.orgUnitCode ?? item.orgUnit,
                                 period: item.period,
                                 enable: false,
                             };
@@ -360,7 +386,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         await compositionRoot.malDataApproval.saveMonitoring(
                             Namespaces.MONITORING,
-                            combiner(
+                            getMonitoringJson(
                                 monitoring,
                                 monitoringValues,
                                 "dataSets",
@@ -415,7 +441,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
             reload,
             isMalApprover,
             isMalAdmin,
-            combiner,
+            getMonitoringJson,
             monitoring,
             config.dataSets,
             dataNotificationsUserGroup,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cv3rb8

### :memo: Implementation
- Change `userGroup` property to `userGroups`
- Store ou code instead of id in datastore on monitoring deactivation

### 📹: Screenshots/Screen capture

https://github.com/EyeSeeTea/d2-reports/assets/37223065/34e2fbbd-b9cf-40e2-b5e0-b5a4c257dc97



### :fire: Notes to the tester
```
REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/
REACT_APP_REPORT_VARIANT=mal-approval-status
```

