### PR TITLE
fix: make monitoring dataset object an array

### DIFF
--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -39,7 +39,13 @@ export interface CountryCode {
     code: string;
 }
 
-export type MonitoringValue = Record<string, Record<string, { monitoring: Monitoring[]; userGroups: string }>>;
+export type MonitoringValue = Record<
+    string,
+    Record<
+        string,
+        { monitoring: Monitoring[]; userGroups: string }[] | { monitoring: Monitoring[]; userGroups: string }[]
+    >
+>;
 
 export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
     return [
@@ -64,7 +70,8 @@ export function getDataDuplicationItemMonitoringValue(
             )?.monitoring ?? false
         );
     } else {
-        const monitoringArray = monitoring["dataSets"]?.[dataSetName]?.monitoring;
+        const monitoringArray = _.first(monitoring["dataSets"]?.[dataSetName])?.monitoring;
+
         return !!_.find(monitoringArray, { orgUnit: dataSet.orgUnitCode, period: dataSet.period });
     }
 }

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -116,28 +116,31 @@ export const DataApprovalList: React.FC = React.memo(() => {
                 userGroup: string
             ): MonitoringValue => {
                 if (!_.isArray(initialMonitoringValues) && initialMonitoringValues) {
-                    const initialMonitoring = initialMonitoringValues[elementType]?.[dataSet]?.monitoring ?? [];
+                    const initialMonitoring =
+                        _.first(initialMonitoringValues[elementType]?.[dataSet])?.monitoring ?? [];
 
                     const newDataSets = _.merge({}, initialMonitoringValues[elementType], {
-                        [dataSet]: _.omit(
-                            {
-                                monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues).map(
-                                    monitoring => {
-                                        return {
-                                            ...monitoring,
-                                            orgUnit:
-                                                monitoring.orgUnit.length > 3
-                                                    ? countryCodes.find(
-                                                          countryCode => countryCode.id === monitoring.orgUnit
-                                                      )?.code
-                                                    : monitoring.orgUnit,
-                                        };
-                                    }
-                                ),
-                                userGroups: userGroup,
-                            },
-                            "userGroup"
-                        ),
+                        [dataSet]: [
+                            _.omit(
+                                {
+                                    monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues).map(
+                                        monitoring => {
+                                            return {
+                                                ...monitoring,
+                                                orgUnit:
+                                                    monitoring.orgUnit.length > 3
+                                                        ? countryCodes.find(
+                                                              countryCode => countryCode.id === monitoring.orgUnit
+                                                          )?.code
+                                                        : monitoring.orgUnit,
+                                            };
+                                        }
+                                    ),
+                                    userGroups: userGroup,
+                                },
+                                "userGroup"
+                            ),
+                        ],
                     });
 
                     return {
@@ -157,10 +160,12 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                     return {
                         [elementType]: {
-                            [dataSet]: {
-                                monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
-                                userGroups: userGroup,
-                            },
+                            [dataSet]: [
+                                {
+                                    monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
+                                    userGroups: userGroup,
+                                },
+                            ],
                         },
                     };
                 }


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cv3rb8

### :memo: Implementation
- Save and get the dataset object as an array

### 📹: Screenshots/Screen capture
https://github.com/EyeSeeTea/d2-reports/assets/37223065/103dba97-49c1-4d82-8d2b-84ff367e382d

### :fire: Notes to the tester
```
REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/
REACT_APP_REPORT_VARIANT=mal-approval-status
```