### PR TITLE
fix: make userGroup property an array

### DIFF
--- a/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
+++ b/src/domain/reports/mal-data-approval/entities/MalDataApprovalItem.ts
@@ -39,13 +39,7 @@ export interface CountryCode {
     code: string;
 }
 
-export type MonitoringValue = Record<
-    string,
-    Record<
-        string,
-        { monitoring: Monitoring[]; userGroups: string }[] | { monitoring: Monitoring[]; userGroups: string }[]
-    >
->;
+export type MonitoringValue = Record<string, Record<string, { monitoring: Monitoring[]; userGroups: string[] }[]>>;
 
 export function getDataDuplicationItemId(dataSet: MalDataApprovalItem): string {
     return [

--- a/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/DataApprovalList.tsx
@@ -113,7 +113,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                 addedMonitoringValues: Monitoring[],
                 elementType: string,
                 dataSet: string,
-                userGroup: string
+                userGroups: string[]
             ): MonitoringValue => {
                 if (!_.isArray(initialMonitoringValues) && initialMonitoringValues) {
                     const initialMonitoring =
@@ -136,7 +136,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                                             };
                                         }
                                     ),
-                                    userGroups: userGroup,
+                                    userGroups,
                                 },
                                 "userGroup"
                             ),
@@ -163,7 +163,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                             [dataSet]: [
                                 {
                                     monitoring: combineMonitoringValues(initialMonitoring, addedMonitoringValues),
-                                    userGroups: userGroup,
+                                    userGroups,
                                 },
                             ],
                         },
@@ -319,7 +319,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                                 monitoringValues,
                                 "dataSets",
                                 config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
-                                dataNotificationsUserGroup
+                                [dataNotificationsUserGroup]
                             )
                         );
 
@@ -354,7 +354,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                                 monitoringValues,
                                 "dataSets",
                                 config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
-                                dataNotificationsUserGroup
+                                [dataNotificationsUserGroup]
                             )
                         );
 
@@ -386,7 +386,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
                                 monitoringValues,
                                 "dataSets",
                                 config.dataSets["PWCUb3Se1Ie"]?.name ?? "",
-                                dataNotificationsUserGroup
+                                [dataNotificationsUserGroup]
                             )
                         );
 


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865cv3rb8

### :memo: Implementation
- Save and get the usergroup property as an array in the monitoring object

### :video_camera: Screenshots/Screen capture
https://github.com/EyeSeeTea/d2-reports/assets/37223065/284b0bfc-9a2d-4c29-98a0-3842149b63a2

### :fire: Notes to the tester
```
REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/
REACT_APP_REPORT_VARIANT=mal-approval-status
```
