### PR TITLE
fix: 409 error on unapprove action

### DIFF
--- a/src/domain/reports/nhwa-approval-status/entities/DataApprovalItem.ts
+++ b/src/domain/reports/nhwa-approval-status/entities/DataApprovalItem.ts
@@ -9,6 +9,7 @@ export interface DataApprovalItem {
     approvalWorkflow: string;
     completed: boolean;
     validated: boolean;
+    approved: boolean;
     lastUpdatedValue: string;
 }
 

--- a/src/webapp/reports/nhwa-approval-status/DataApprovalViewModel.ts
+++ b/src/webapp/reports/nhwa-approval-status/DataApprovalViewModel.ts
@@ -17,6 +17,7 @@ export interface DataApprovalViewModel {
     completed: boolean;
     validated: boolean;
     lastUpdatedValue: Date;
+    approved: boolean;
 }
 
 export function getDataApprovalViews(_config: Config, items: DataApprovalItem[]): DataApprovalViewModel[] {
@@ -34,6 +35,7 @@ export function getDataApprovalViews(_config: Config, items: DataApprovalItem[])
             completed: item.completed,
             validated: item.validated,
             lastUpdatedValue: new Date(item.lastUpdatedValue),
+            approved: item.approved,
         };
     });
 }

--- a/src/webapp/reports/nhwa-approval-status/data-approval-list/DataApprovalList.tsx
+++ b/src/webapp/reports/nhwa-approval-status/data-approval-list/DataApprovalList.tsx
@@ -103,7 +103,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: rows => _.every(rows, row => row.validated === false),
+                    isActive: rows => _.every(rows, row => row.approved === false),
                 },
                 {
                     name: "unapprove",
@@ -119,7 +119,7 @@ export const DataApprovalList: React.FC = React.memo(() => {
 
                         reload();
                     },
-                    isActive: rows => _.every(rows, row => row.validated === true),
+                    isActive: rows => _.every(rows, row => row.approved === true),
                 },
             ],
             initialSorting: {


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/865d1t546

### :memo: Implementation
- **Problem**: The `approved` and `unapproved` actions are visible on the wrong rows.  
- **Solution**: A new `approved` property is added to each table row. `approved` is the `mayUnapprove` boolean value gotten from the `/dataApprovals` endpoint.   

### :video_camera: Screenshots/Screen capture

https://github.com/EyeSeeTea/d2-reports/assets/37223065/a8061332-5db9-4933-88d2-f5da07b40844



### :fire: Notes to the tester
`REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/`
`REACT_APP_REPORT_VARIANT=mal-subscription-status`