### PR TITLE
fix: ou selector filters out some ous

### DIFF
--- a/src/webapp/reports/csy-audit-trauma/csy-audit-trauma-list/Filters.tsx
+++ b/src/webapp/reports/csy-audit-trauma/csy-audit-trauma-list/Filters.tsx
@@ -2,10 +2,10 @@ import React, { useMemo, useState } from "react";
 import { OrgUnitsFilterButton } from "../../../components/org-units-filter/OrgUnitsFilterButton";
 import { useAppContext } from "../../../contexts/app-context";
 import { Id } from "../../../../domain/common/entities/Base";
-import { getRootIds } from "../../../../domain/common/entities/OrgUnit";
 import styled from "styled-components";
 import { Dropdown, DropdownProps } from "@eyeseetea/d2-ui-components";
 import i18n from "../../../../locales";
+import _ from "lodash";
 
 export interface FiltersProps {
     values: Filter;
@@ -82,7 +82,13 @@ export const Filters: React.FC<FiltersProps> = React.memo(props => {
 
     const [periodType, setPerType] = useState<string>("yearly");
 
-    const rootIds = React.useMemo(() => getRootIds(config.currentUser.orgUnits), [config]);
+    const rootIds = React.useMemo(
+        () =>
+            _(config.currentUser.orgUnits)
+                .map(ou => ou.id)
+                .value(),
+        [config]
+    );
 
     const periodTypeItems = React.useMemo(() => {
         return [


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/862khx52c

### :memo: Implementation
**Problem**: the OU filter in the report only returns the orgUnits with the minimum level
**Solution**: the OU filter now returns all the orgUnits the user is assigned to 

### :video_camera: Screenshots/Screen capture
<img width="1428" alt="Screenshot 2023-11-08 at 09 58 03" src="https://github.com/EyeSeeTea/d2-reports/assets/37223065/942ae56b-96d5-4eca-aad7-84873c377af6">


### :fire: Notes to the tester
`REACT_APP_DHIS2_BASE_URL=https://dev.eyeseetea.com/who-dev-238/`
`REACT_APP_REPORT_VARIANT=csy-audit-trauma`
