### PR TITLE
add subnational dataSet to autocomplete compute report

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-05T06:42:58.086Z\n"
-"PO-Revision-Date: 2024-04-05T06:42:58.086Z\n"
+"POT-Creation-Date: 2024-04-17T18:11:26.697Z\n"
+"PO-Revision-Date: 2024-04-17T18:11:26.697Z\n"
 
 msgid "<No value>"
 msgstr ""
@@ -56,6 +56,16 @@ msgid "This will take a long time."
 msgstr ""
 
 msgid "Are you sure?"
+msgstr ""
+
+msgid ""
+"Module 1 totals with missing sum or sum that does not match the "
+"auto-calculated"
+msgstr ""
+
+msgid ""
+"Module 1 (Subnational single entry) totals with missing sum or sum that "
+"does not match the auto-calculated"
 msgstr ""
 
 msgid "Metadata Admin Report"
@@ -706,11 +716,6 @@ msgid "Fix all incorrect values"
 msgstr ""
 
 msgid "Updating values..."
-msgstr ""
-
-msgid ""
-"Module 1 totals with missing sum or sum that does not match the "
-"auto-calculated"
 msgstr ""
 
 msgid "NHWA Comments Report"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-04-05T06:42:58.086Z\n"
+"POT-Creation-Date: 2024-04-17T18:11:26.697Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -56,6 +56,16 @@ msgid "This will take a long time."
 msgstr ""
 
 msgid "Are you sure?"
+msgstr ""
+
+msgid ""
+"Module 1 totals with missing sum or sum that does not match the auto-"
+"calculated"
+msgstr ""
+
+msgid ""
+"Module 1 (Subnational single entry) totals with missing sum or sum that does "
+"not match the auto-calculated"
 msgstr ""
 
 msgid "Metadata Admin Report"
@@ -708,11 +718,6 @@ msgstr ""
 msgid "Updating values..."
 msgstr ""
 
-msgid ""
-"Module 1 totals with missing sum or sum that does not match the auto-"
-"calculated"
-msgstr ""
-
 msgid "NHWA Comments Report"
 msgstr ""
 
@@ -734,9 +739,8 @@ msgstr ""
 msgid "No values to update"
 msgstr ""
 
-#, fuzzy
 msgid "Occupation"
-msgstr "Configuración"
+msgstr ""
 
 msgid "Practising"
 msgstr ""

--- a/src/compositionRoot.ts
+++ b/src/compositionRoot.ts
@@ -97,6 +97,7 @@ import { GetATCRecalculationLogicUseCase } from "./domain/reports/glass-admin/us
 import { CancelRecalculationUseCase } from "./domain/reports/glass-admin/usecases/CancelRecalculationUseCase";
 import { GetGLASSDataSubmissionModulesUseCase } from "./domain/reports/glass-data-submission/usecases/GetGLASSDataSubmissionModulesUseCase";
 import { SaveAuthoritiesMonitoringUseCase } from "./domain/reports/authorities-monitoring/usecases/SaveAuthoritiesMonitoringUseCase";
+import { GetAutoCompleteComputeSettingsUseCase } from "./domain/reports/nhwa-auto-complete-compute/usecases/GetAutoCompleteComputeSettingsUseCase";
 
 export function getCompositionRoot(api: D2Api) {
     const configRepository = new Dhis2ConfigRepository(api, getReportType());
@@ -217,10 +218,12 @@ export function getCompositionRoot(api: D2Api) {
             get: new GetConfig(configRepository),
         }),
         nhwa: {
+            getAutoCompleteComputeSettings: new GetAutoCompleteComputeSettingsUseCase(
+                autoCompleteComputeSettingsRepository
+            ),
             getAutoCompleteComputeValues: new GetAutoCompleteComputeValuesUseCase(
                 dataSetRepository,
-                dataValuesRepository,
-                autoCompleteComputeSettingsRepository
+                dataValuesRepository
             ),
             fixAutoCompleteComputeValues: new FixAutoCompleteComputeValuesUseCase(dataValuesRepository),
             getTotalsByActivityLevel: new GetTotalsByActivityLevelUseCase(

--- a/src/data/common/DataSetD2Repository.ts
+++ b/src/data/common/DataSetD2Repository.ts
@@ -33,7 +33,8 @@ export class DataSetD2Repository implements DataSetRepository {
                         },
                         organisationUnits: {
                             id: true,
-                            name: true,
+                            displayName: true,
+                            level: true,
                         },
                     },
                     filter: {
@@ -60,8 +61,8 @@ export class DataSetD2Repository implements DataSetRepository {
                         organisationUnits: d2DataSet.organisationUnits.map(d2OrgUnit => {
                             return {
                                 id: d2OrgUnit.id,
-                                name: d2OrgUnit.name,
-                                level: 0,
+                                name: d2OrgUnit.displayName,
+                                level: d2OrgUnit.level,
                                 path: "",
                             };
                         }),

--- a/src/data/common/DataValuesD2Repository.ts
+++ b/src/data/common/DataValuesD2Repository.ts
@@ -17,6 +17,7 @@ export class DataValuesD2Repository implements DataValuesRepository {
             period: options.periods,
             startDate: options.startDate,
             endDate: options.endDate,
+            children: options.children,
         });
 
         const res = await res$.getData();

--- a/src/data/reports/nhwa-auto-complete-compute/AutoCompleteComputeSettingsD2Repository.ts
+++ b/src/data/reports/nhwa-auto-complete-compute/AutoCompleteComputeSettingsD2Repository.ts
@@ -6,8 +6,7 @@ import { d2ReportsDataStoreNamespace } from "../../common/clients/storage/Namesp
 export class AutoCompleteComputeSettingsD2Repository implements AutoCompleteComputeSettingsRepository {
     constructor(private api: D2Api) {}
 
-    async get(): Promise<AutoCompleteComputeSettings> {
-        const key = "nhwa-auto-complete-compute";
+    async get(key: string): Promise<AutoCompleteComputeSettings> {
         const dataStore = this.api.dataStore(d2ReportsDataStoreNamespace);
         const config = await dataStore.get<AutoCompleteComputeSettings>(key).getData();
         if (!config) {

--- a/src/domain/common/entities/DataValue.ts
+++ b/src/domain/common/entities/DataValue.ts
@@ -18,6 +18,7 @@ export interface DataValuesSelector {
     periods?: string[];
     startDate?: string;
     endDate?: string;
+    children?: boolean;
 }
 
 export type DataValueToPost = Omit<

--- a/src/domain/common/entities/Stats.ts
+++ b/src/domain/common/entities/Stats.ts
@@ -1,6 +1,11 @@
+import { Id } from "./Base";
+
 export type Stats = {
     imported: number;
     updated: number;
     ignored: number;
     deleted: number;
+    errorMessages: StatsError[];
 };
+
+type StatsError = { id: Id; message: string };

--- a/src/domain/reports/nhwa-auto-complete-compute/repositores/AutoCompleteComputeSettingsRepository.ts
+++ b/src/domain/reports/nhwa-auto-complete-compute/repositores/AutoCompleteComputeSettingsRepository.ts
@@ -1,5 +1,5 @@
 import { AutoCompleteComputeSettings } from "../entities/AutoCompleteComputeSettings";
 
 export interface AutoCompleteComputeSettingsRepository {
-    get(): Promise<AutoCompleteComputeSettings>;
+    get(key: string): Promise<AutoCompleteComputeSettings>;
 }

--- a/src/domain/reports/nhwa-auto-complete-compute/usecases/FixAutoCompleteComputeValuesUseCase.ts
+++ b/src/domain/reports/nhwa-auto-complete-compute/usecases/FixAutoCompleteComputeValuesUseCase.ts
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import { AutoCompleteComputeViewModel } from "../../../../webapp/reports/nhwa-auto-complete-compute/NHWAAutoCompleteCompute";
 import { DataValueToPost } from "../../../common/entities/DataValue";
 import { Stats } from "../../../common/entities/Stats";
@@ -21,6 +22,10 @@ export class FixAutoCompleteComputeValuesUseCase {
             imported: statsSaved.imported + statsDeleted.imported,
             updated: statsSaved.updated + statsDeleted.updated,
             ignored: statsSaved.ignored + statsDeleted.ignored,
+            errorMessages: _(statsSaved.errorMessages)
+                .concat(statsDeleted.errorMessages)
+                .uniqBy(message => message.message)
+                .value(),
         };
     }
 

--- a/src/domain/reports/nhwa-auto-complete-compute/usecases/GetAutoCompleteComputeSettingsUseCase.ts
+++ b/src/domain/reports/nhwa-auto-complete-compute/usecases/GetAutoCompleteComputeSettingsUseCase.ts
@@ -1,0 +1,12 @@
+import { AutoCompleteComputeSettings } from "../entities/AutoCompleteComputeSettings";
+import { AutoCompleteComputeSettingsRepository } from "../repositores/AutoCompleteComputeSettingsRepository";
+
+export class GetAutoCompleteComputeSettingsUseCase {
+    constructor(private settingsRepository: AutoCompleteComputeSettingsRepository) {}
+
+    async execute(options: GetAutoCompleteComputeSettingsOptions): Promise<AutoCompleteComputeSettings> {
+        return this.settingsRepository.get(options.settingsKey);
+    }
+}
+
+type GetAutoCompleteComputeSettingsOptions = { settingsKey: string };

--- a/src/domain/reports/nhwa-auto-complete-compute/usecases/GetAutoCompleteComputeValuesUseCase.ts
+++ b/src/domain/reports/nhwa-auto-complete-compute/usecases/GetAutoCompleteComputeValuesUseCase.ts
@@ -6,8 +6,7 @@ import {
 import { CategoryOptionCombo, DataElement } from "../../../common/entities/DataSet";
 import { DataSetRepository } from "../../../common/repositories/DataSetRepository";
 import { DataValuesRepository } from "../../../common/repositories/DataValuesRepository";
-import { DataElementTotal } from "../entities/AutoCompleteComputeSettings";
-import { AutoCompleteComputeSettingsRepository } from "../repositores/AutoCompleteComputeSettingsRepository";
+import { AutoCompleteComputeSettings, DataElementTotal } from "../entities/AutoCompleteComputeSettings";
 import { DataValue } from "./../../../common/entities/DataValue";
 import { promiseMap } from "../../../../utils/promises";
 
@@ -17,20 +16,14 @@ export type AutoCompleteComputeValuesFilter = {
     pageSize: number;
     sortingField: string;
     sortingOrder: "asc" | "desc";
-    filters: {
-        periods: string[];
-        orgUnits: string[];
-    };
+    filters: { periods: string[]; orgUnits: string[] };
+    settings: AutoCompleteComputeSettings;
 };
 
 export class GetAutoCompleteComputeValuesUseCase {
     dataCache: { key: string; value: AutoCompleteComputeViewModel[] } | undefined;
 
-    constructor(
-        private dataSetRepository: DataSetRepository,
-        private dataValuesRepository: DataValuesRepository,
-        private settingsRepository: AutoCompleteComputeSettingsRepository
-    ) {}
+    constructor(private dataSetRepository: DataSetRepository, private dataValuesRepository: DataValuesRepository) {}
 
     async execute(options: AutoCompleteComputeValuesFilter): Promise<AutoCompleteComputeViewModelWithPaging> {
         const autoCompleteValues = await this.getAllAutoCompleteValues(options);
@@ -50,8 +43,7 @@ export class GetAutoCompleteComputeValuesUseCase {
     private async getAllAutoCompleteValues(
         options: AutoCompleteComputeValuesFilter
     ): Promise<AutoCompleteComputeViewModel[]> {
-        const settings = await this.settingsRepository.get();
-        const { cacheKey, filters } = options;
+        const { cacheKey, filters, settings } = options;
         if (this.dataCache && this.dataCache.key === cacheKey) return this.dataCache.value;
 
         const dataSets = await this.dataSetRepository.getById(settings.dataSet);

--- a/src/webapp/components/alert-stats-errors/AlertStatsErrors.tsx
+++ b/src/webapp/components/alert-stats-errors/AlertStatsErrors.tsx
@@ -1,0 +1,50 @@
+import _ from "lodash";
+import React from "react";
+import styled from "styled-components";
+import { Button } from "@material-ui/core";
+import { OrgUnit } from "../../../domain/common/entities/OrgUnit";
+import { Stats } from "../../../domain/common/entities/Stats";
+import { Alert } from "../alert/Alert";
+
+type AlertStatsErrorsProps = { errors?: Stats["errorMessages"]; onCleanError: () => void; orgUnits: OrgUnit[] };
+
+function replaceOrgUnitIdByName(message: string, orgUnits: OrgUnit[]): string {
+    if (orgUnits.length === 0) return message;
+    const regex = /organisation unit:\s*`([^`]+)`/;
+    const match = message.match(regex);
+    if (match) {
+        const orgUnitId = _(match).nth(1);
+        if (!orgUnitId) return message;
+        const orgUnit = orgUnits.find(orgUnit => orgUnit.id === orgUnitId);
+        if (!orgUnit) return message;
+        return message.replace(orgUnitId, orgUnit.name);
+    } else {
+        return message;
+    }
+}
+
+export const AlertStatsErrors: React.FC<AlertStatsErrorsProps> = props => {
+    const { errors, onCleanError, orgUnits } = props;
+
+    if (!errors) return null;
+
+    return (
+        <>
+            <Button variant="contained" color="secondary" size="small" onClick={() => onCleanError()}>
+                Clear Errors
+            </Button>
+            <AlertContainer>
+                {errors.map((error, index) => {
+                    return <Alert key={index} message={replaceOrgUnitIdByName(error.message, orgUnits)} />;
+                })}
+            </AlertContainer>
+        </>
+    );
+};
+
+const AlertContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5em;
+    padding: 0.5em 0;
+`;

--- a/src/webapp/components/alert/Alert.tsx
+++ b/src/webapp/components/alert/Alert.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { Typography, makeStyles } from "@material-ui/core";
+import ErrorIcon from "@material-ui/icons/ErrorOutline";
+
+type AlertProps = { message: string };
+
+export const Alert: React.FC<AlertProps> = props => {
+    const { message } = props;
+    const classes = useStyles();
+    return (
+        <div className={classes.alertContainer}>
+            <ErrorIcon htmlColor="#f44336" />
+            <Typography variant="body1" component="p">
+                {message}
+            </Typography>
+        </div>
+    );
+};
+
+const useStyles = makeStyles({
+    alertContainer: {
+        alignItems: "center",
+        backgroundColor: "rgb(253, 236, 234)",
+        color: "rgb(97, 26, 21)",
+        display: "flex",
+        gap: "1em",
+        padding: "0.5em 1em",
+    },
+});

--- a/src/webapp/hooks/UseAutocompleteCompute.tsx
+++ b/src/webapp/hooks/UseAutocompleteCompute.tsx
@@ -1,0 +1,26 @@
+import { useLoading, useSnackbar } from "@eyeseetea/d2-ui-components";
+import React from "react";
+import { AutoCompleteComputeSettings } from "../../domain/reports/nhwa-auto-complete-compute/entities/AutoCompleteComputeSettings";
+import { useAppContext } from "../contexts/app-context";
+
+type UseSettingsProps = { settingKey: string };
+
+export function useSettings(props: UseSettingsProps) {
+    const { compositionRoot } = useAppContext();
+    const loading = useLoading();
+    const snackbar = useSnackbar();
+    const [settings, setSettings] = React.useState<AutoCompleteComputeSettings>();
+
+    React.useEffect(() => {
+        compositionRoot.nhwa.getAutoCompleteComputeSettings
+            .execute({ settingsKey: props.settingKey })
+            .then(result => {
+                setSettings(result);
+            })
+            .catch(error => {
+                snackbar.error(error.message);
+            });
+    }, [props.settingKey, compositionRoot, loading, snackbar]);
+
+    return { settings };
+}

--- a/src/webapp/reports/Reports.tsx
+++ b/src/webapp/reports/Reports.tsx
@@ -16,6 +16,7 @@ import { NHWAFixTotals } from "./nhwa-fix-totals-activity-level/NHWAFixTotals";
 import { NHWASubnationalCorrectOrgUnit } from "./nhwa-subnational-correct-orgunit/NHWASubnationalCorrectOrgUnit";
 import AuthoritiesMonitoringReport from "./authorities-monitoring/AuthoritiesMonitoringReport";
 import GLASSAdminReport from "./glass-admin/GLASSAdminReport";
+import i18n from "../../locales";
 
 const widget = process.env.REACT_APP_REPORT_VARIANT || "";
 
@@ -61,7 +62,13 @@ const Component: React.FC = () => {
             return <DataQualityReport />;
         }
         case "nhwa-auto-complete-compute": {
-            return <NHWAAutoCompleteCompute />;
+            return (
+                <NHWAAutoCompleteCompute
+                    countryLevel="3"
+                    settingsKey="nhwa-auto-complete-compute"
+                    title={i18n.t("Module 1 totals with missing sum or sum that does not match the auto-calculated")}
+                />
+            );
         }
         case "nhwa-fix-totals-activity-level": {
             return <NHWAFixTotals />;
@@ -71,6 +78,17 @@ const Component: React.FC = () => {
         }
         case "authorities-monitoring": {
             return <AuthoritiesMonitoringReport />;
+        }
+        case "nhwa-auto-complete-compute-subnational": {
+            return (
+                <NHWAAutoCompleteCompute
+                    countryLevel="4"
+                    settingsKey="nhwa-auto-complete-compute-subnational"
+                    title={i18n.t(
+                        "Module 1 (Subnational single entry) totals with missing sum or sum that does not match the auto-calculated"
+                    )}
+                />
+            );
         }
         default: {
             return <p>{`Please provide a valid REACT_APP_REPORT_VARIANT`}</p>;

--- a/src/webapp/reports/common/Filters.tsx
+++ b/src/webapp/reports/common/Filters.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styled from "styled-components";
 import { MultipleDropdown } from "@eyeseetea/d2-ui-components";
 import { OrgUnit } from "../../../domain/common/entities/OrgUnit";
-import { countryLevel, defaultPeriods } from "./nhwa-settings";
+import { defaultPeriods } from "./nhwa-settings";
 import { OrgUnitsFilterButton } from "../../components/org-units-filter/OrgUnitsFilterButton";
 import { D2Api } from "./../../../types/d2-api";
 import i18n from "../../../locales";
@@ -35,7 +35,7 @@ export const Filters: React.FC<FiltersProps> = React.memo(props => {
                 rootIds={rootIds}
                 selected={selectedOrgUnits}
                 setSelected={setSelectedOrgUnits}
-                selectableLevels={[countryLevel]}
+                // selectableLevels={[countryLevel]}
                 selectableIds={orgUnits.map(ou => ou.id)}
             />
 

--- a/src/webapp/reports/nhwa-auto-complete-compute/NHWAAutoCompleteCompute.tsx
+++ b/src/webapp/reports/nhwa-auto-complete-compute/NHWAAutoCompleteCompute.tsx
@@ -1,7 +1,6 @@
 import _ from "lodash";
 import React from "react";
-import styled from "styled-components";
-import { Button, Typography, makeStyles } from "@material-ui/core";
+import { Typography, makeStyles } from "@material-ui/core";
 import {
     ObjectsList,
     TableConfig,
@@ -21,7 +20,7 @@ import { countryLevel } from "../common/nhwa-settings";
 import { useReload } from "../../utils/use-reload";
 import { Filters } from "../common/Filters";
 import { Stats } from "../../../domain/common/entities/Stats";
-import { Alert } from "../../components/alert/Alert";
+import { AlertStatsErrors } from "../../components/alert-stats-errors/AlertStatsErrors";
 
 export type AutoCompleteComputeViewModelWithPaging = {
     page: number;
@@ -41,20 +40,6 @@ export type AutoCompleteComputeViewModel = {
     valueToFix: string;
     currentValue: string | undefined;
 };
-
-function replaceOrgUnitIdByName(message: string, orgUnits: OrgUnit[]): string {
-    const regex = /organisation unit:\s*`([^`]+)`/;
-    const match = message.match(regex);
-    if (match) {
-        const orgUnitId = _(match).nth(1);
-        if (!orgUnitId) return message;
-        const orgUnit = orgUnits.find(orgUnit => orgUnit.id === orgUnitId);
-        if (!orgUnit) return message;
-        return message.replace(orgUnitId, orgUnit.name);
-    } else {
-        return message;
-    }
-}
 
 export const NHWAAutoCompleteCompute: React.FC = () => {
     const { compositionRoot, api, config } = useAppContext();
@@ -189,6 +174,8 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
                 {i18n.t("Module 1 totals with missing sum or sum that does not match the auto-calculated")}
             </Typography>
 
+            <AlertStatsErrors errors={errors} onCleanError={() => setErrors(undefined)} orgUnits={orgUnits} />
+
             <ObjectsList<AutoCompleteComputeViewModel> {...tableProps} onChangeSearch={undefined}>
                 <Filters
                     api={api}
@@ -206,28 +193,8 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
                     }}
                 />
             </ObjectsList>
-
-            {errors && (
-                <>
-                    <Button variant="contained" color="secondary" size="small" onClick={() => setErrors(undefined)}>
-                        Clear Errors
-                    </Button>
-                    <AlertContainer>
-                        {errors.map((error, index) => {
-                            return <Alert key={index} message={replaceOrgUnitIdByName(error.message, orgUnits)} />;
-                        })}
-                    </AlertContainer>
-                </>
-            )}
         </div>
     );
 };
-
-const AlertContainer = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0.5em;
-    padding: 0.5em 0;
-`;
 
 const useStyles = makeStyles({ wrapper: { padding: 20 } });

--- a/src/webapp/reports/nhwa-auto-complete-compute/NHWAAutoCompleteCompute.tsx
+++ b/src/webapp/reports/nhwa-auto-complete-compute/NHWAAutoCompleteCompute.tsx
@@ -16,11 +16,13 @@ import i18n from "../../../locales";
 import { useAppContext } from "../../contexts/app-context";
 import { getOrgUnitIdsFromPaths, getRootIds, OrgUnit } from "../../../domain/common/entities/OrgUnit";
 import { CategoryOptionCombo, DataElement } from "../../../domain/common/entities/DataSet";
-import { countryLevel } from "../common/nhwa-settings";
 import { useReload } from "../../utils/use-reload";
 import { Filters } from "../common/Filters";
 import { Stats } from "../../../domain/common/entities/Stats";
 import { AlertStatsErrors } from "../../components/alert-stats-errors/AlertStatsErrors";
+import { useSettings } from "../../hooks/UseAutocompleteCompute";
+
+export type NHWAAutoCompleteComputeProps = { countryLevel: string; settingsKey: string; title: string };
 
 export type AutoCompleteComputeViewModelWithPaging = {
     page: number;
@@ -41,7 +43,8 @@ export type AutoCompleteComputeViewModel = {
     currentValue: string | undefined;
 };
 
-export const NHWAAutoCompleteCompute: React.FC = () => {
+export const NHWAAutoCompleteCompute: React.FC<NHWAAutoCompleteComputeProps> = props => {
+    const { countryLevel, settingsKey, title } = props;
     const { compositionRoot, api, config } = useAppContext();
     const loading = useLoading();
     const snackbar = useSnackbar();
@@ -52,15 +55,17 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
     const [errors, setErrors] = React.useState<Stats["errorMessages"]>();
     const classes = useStyles();
 
+    const { settings } = useSettings({ settingKey: settingsKey });
+
     const rootIds = React.useMemo(() => getRootIds(config.currentUser.orgUnits), [config]);
 
     React.useEffect(() => {
         async function loadOrgUnits() {
-            const orgUnits = await compositionRoot.orgUnits.getByLevel(String(countryLevel));
+            const orgUnits = await compositionRoot.orgUnits.getByLevel(countryLevel);
             setOrgUnits(orgUnits);
         }
         loadOrgUnits();
-    }, [compositionRoot.orgUnits]);
+    }, [compositionRoot.orgUnits, countryLevel]);
 
     const baseConfig: TableConfig<AutoCompleteComputeViewModel> = React.useMemo(
         () => ({
@@ -92,7 +97,6 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
                     getValue: row => row.currentValue || "Empty",
                 },
             ],
-
             actions: [],
             initialSorting: {
                 field: "dataElement" as const,
@@ -108,9 +112,10 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
                     icon: <DoneAllIcon />,
                     text: i18n.t("Fix all incorrect values"),
                     onClick: async ids => {
-                        if (ids.length === 0) return;
+                        if (ids.length === 0 || !settings) return;
                         loading.show(true, i18n.t("Updating values..."));
                         const results = await compositionRoot.nhwa.getAutoCompleteComputeValues.execute({
+                            settings: settings,
                             cacheKey: reloadKey,
                             page: 1,
                             pageSize: 1e6,
@@ -143,13 +148,15 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
                 },
             ],
         }),
-        [compositionRoot, loading, snackbar, reload, reloadKey, selectedOrgUnits, selectedPeriods]
+        [compositionRoot, loading, snackbar, reload, reloadKey, selectedOrgUnits, selectedPeriods, settings]
     );
 
     const getRows = React.useMemo(
         () => async (_search: string, paging: TablePagination, sorting: TableSorting<AutoCompleteComputeViewModel>) => {
+            if (!settings) return { objects: [], pager: { page: 0, pageCount: 0, pageSize: 10, rows: [], total: 0 } };
             loading.show(true, i18n.t("Loading..."));
             const results = await compositionRoot.nhwa.getAutoCompleteComputeValues.execute({
+                settings: settings,
                 cacheKey: reloadKey,
                 page: paging.page,
                 pageSize: paging.pageSize,
@@ -163,7 +170,7 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
             loading.hide();
             return { pager: { ...results }, objects: results.rows };
         },
-        [compositionRoot, reloadKey, selectedOrgUnits, selectedPeriods, loading]
+        [compositionRoot, reloadKey, selectedOrgUnits, selectedPeriods, loading, settings]
     );
 
     const tableProps = useObjectsTable(baseConfig, getRows);
@@ -171,7 +178,7 @@ export const NHWAAutoCompleteCompute: React.FC = () => {
     return (
         <div className={classes.wrapper}>
             <Typography variant="h5" gutterBottom>
-                {i18n.t("Module 1 totals with missing sum or sum that does not match the auto-calculated")}
+                {title}
             </Typography>
 
             <AlertStatsErrors errors={errors} onCleanError={() => setErrors(undefined)} orgUnits={orgUnits} />

--- a/src/webapp/reports/nhwa-subnational-correct-orgunit/NHWASubnationalCorrectOrgUnit.tsx
+++ b/src/webapp/reports/nhwa-subnational-correct-orgunit/NHWASubnationalCorrectOrgUnit.tsx
@@ -1,3 +1,4 @@
+import _ from "lodash";
 import React from "react";
 import { Typography, makeStyles } from "@material-ui/core";
 import {
@@ -44,7 +45,8 @@ export const NHWASubnationalCorrectOrgUnit: React.FC = () => {
                 compositionRoot.nhwa.dismissSubnationalCorrectValues
                     .execute(onlyRowsSelected)
                     .then(stats => {
-                        snackbar.openSnackbar("success", JSON.stringify(stats, null, 4), {
+                        const statsWithoutErrorMessages = _(stats).omit("errorMessages").value();
+                        snackbar.openSnackbar("success", JSON.stringify(statsWithoutErrorMessages, null, 4), {
                             autoHideDuration: 5000,
                         });
                         reload();


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694b877m

### :memo: Implementation

### :video_camera: Screenshots/Screen capture

[DHIS2-Reports_subnational_report.webm](https://github.com/EyeSeeTea/d2-reports/assets/461124/0204c4af-989f-4aea-9286-2cd05078f8d7)

### :fire: Notes to the tester

This PR has a dependency on PR [146](https://github.com/EyeSeeTea/d2-reports/pull/146) to keep the same logic related to how dataValues are being updated.

- Create configuration in dataStore: 
namespace = `d2-reports`
key: `nhwa-auto-complete-compute-subnational` (json configuration attached in issue)

- Add the variant to the `.env.local` file: `REACT_APP_REPORT_VARIANT=nhwa-auto-complete-compute-subnational`

- `yarn start`

#8694b877m