### PR TITLE
add build for auto compute subnational report

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,9 @@
         "nhwa-auto-complete-compute-manifest": "d2-manifest package.json build/manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-auto-complete-compute",
         "nhwa-auto-complete-compute-build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-auto-complete-compute && react-scripts build && yarn run nhwa-auto-complete-compute-manifest && cp -r i18n icon.png build",
         "nhwa-auto-complete-compute-build": "REACT_APP_DHIS2_BASE_URL='' REACT_APP_DHIS2_AUTH='' yarn nhwa-auto-complete-compute-build-folder && rm -f $npm_package_name.zip && cd build && rm -f manifest.json mal-favicon.ico && zip --quiet -r ../$npm_package_name.zip *",
+        "nhwa-auto-complete-compute-subnational-manifest": "d2-manifest package.json build/manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-auto-complete-compute-subnational",
+        "nhwa-auto-complete-compute-subnational-build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-auto-complete-compute-subnational && react-scripts build && yarn run nhwa-auto-complete-compute-subnational-manifest && cp -r i18n icon.png build",
+        "nhwa-auto-complete-compute-subnational-build": "REACT_APP_DHIS2_BASE_URL='' REACT_APP_DHIS2_AUTH='' yarn nhwa-auto-complete-compute-subnational-build-folder && rm -f $npm_package_name.zip && cd build && rm -f manifest.json mal-favicon.ico && zip --quiet -r ../$npm_package_name.zip *",
         "nhwa-fix-totals-activity-level-manifest": "d2-manifest package.json build/manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-fix-totals-activity-level",
         "nhwa-fix-totals-activity-level-build-folder": "rm -rf build/ && d2-manifest package.json manifest.webapp --manifest.version=$npm_package_reportVersions_nhwa-fix-totals-activity-level && react-scripts build && yarn run nhwa-fix-totals-activity-level-manifest && cp -r i18n icon.png build",
         "nhwa-fix-totals-activity-level-build": "REACT_APP_DHIS2_BASE_URL='' REACT_APP_DHIS2_AUTH='' yarn nhwa-fix-totals-activity-level-build-folder && rm -f $npm_package_name.zip && cd build && rm -f manifest.json mal-favicon.ico && zip --quiet -r ../$npm_package_name.zip *",
@@ -126,6 +129,7 @@
         "mal": "0.1.3",
         "mal-subscription": "1.0.0",
         "nhwa-auto-complete-compute": "1.0.0",
+        "nhwa-auto-complete-compute-subnational": "1.0.0",
         "nhwa-fix-totals-activity-level": "1.0.0",
         "nhwa-subnational-correct-orgunit": "1.0.0",
         "nhwa": "1.0.0"


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694b877m

### :memo: Implementation

### :video_camera: Screenshots/Screen capture

### :fire: Notes to the tester

- update .env.local file with the subnational report variant

```bash
REACT_APP_REPORT_VARIANT=nhwa-auto-complete-compute-subnational
```

- build the report

```bash
yarn build-report
```

- Report is being generated at `dist/index.html`.

- Upload it to the standard report app.

#8694b877m