### PR TITLE
filter dataSet in Malaria Data Approval Report

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-04-17T18:11:26.697Z\n"
-"PO-Revision-Date: 2024-04-17T18:11:26.697Z\n"
+"POT-Creation-Date: 2024-05-22T17:13:09.045Z\n"
+"PO-Revision-Date: 2024-05-22T17:13:09.045Z\n"
 
 msgid "<No value>"
 msgstr ""
@@ -395,16 +395,13 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+msgid "Select File"
+msgstr ""
+
 msgid "Version has been successfully patched"
 msgstr ""
 
-msgid "Error encountered when parsing version"
-msgstr ""
-
 msgid "Upload finished"
-msgstr ""
-
-msgid "Error parsing the file"
 msgstr ""
 
 msgid "Recalculation has been cancelled successfully"
@@ -778,4 +775,25 @@ msgid "Dismiss"
 msgstr ""
 
 msgid "Module 1 (subnational) with fixes for organisation unit name"
+msgstr ""
+
+msgid "User Two Factor Monitoring"
+msgstr ""
+
+msgid "External auth"
+msgstr ""
+
+msgid "TwoFA"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "Disabled"
+msgstr ""
+
+msgid "User groups"
+msgstr ""
+
+msgid "Open ID"
 msgstr ""

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-04-17T18:11:26.697Z\n"
+"POT-Creation-Date: 2024-05-22T17:13:09.045Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -395,16 +395,13 @@ msgstr ""
 msgid "Continue"
 msgstr ""
 
+msgid "Select File"
+msgstr ""
+
 msgid "Version has been successfully patched"
 msgstr ""
 
-msgid "Error encountered when parsing version"
-msgstr ""
-
 msgid "Upload finished"
-msgstr ""
-
-msgid "Error parsing the file"
 msgstr ""
 
 msgid "Recalculation has been cancelled successfully"
@@ -778,6 +775,27 @@ msgid "Dismiss"
 msgstr ""
 
 msgid "Module 1 (subnational) with fixes for organisation unit name"
+msgstr ""
+
+msgid "User Two Factor Monitoring"
+msgstr ""
+
+msgid "External auth"
+msgstr ""
+
+msgid "TwoFA"
+msgstr ""
+
+msgid "Email"
+msgstr ""
+
+msgid "Disabled"
+msgstr ""
+
+msgid "User groups"
+msgstr ""
+
+msgid "Open ID"
 msgstr ""
 
 #~ msgid "Add"

--- a/src/data/common/Dhis2ConfigRepository.ts
+++ b/src/data/common/Dhis2ConfigRepository.ts
@@ -147,6 +147,7 @@ export class Dhis2ConfigRepository implements ConfigRepository {
             dataSets: {
                 fields: {
                     id: true,
+                    code: true,
                     displayName: toName,
                     dataSetElements: {
                         dataElement: { id: true, name: true },

--- a/src/domain/common/entities/Config.ts
+++ b/src/domain/common/entities/Config.ts
@@ -4,7 +4,7 @@ import { getPath } from "./OrgUnit";
 import { User } from "./User";
 
 export interface Config {
-    dataSets: Record<Id, NamedRef>;
+    dataSets: Record<Id, NamedRef & { code: string | undefined }>;
     sections: Record<Id, NamedRef> | undefined;
     currentUser: User;
     sqlViews: Record<string, NamedRef>;

--- a/src/webapp/reports/mal-data-approval/MalDataApprovalReport.tsx
+++ b/src/webapp/reports/mal-data-approval/MalDataApprovalReport.tsx
@@ -18,7 +18,7 @@ const MalDataApprovalStatusReport: React.FC = () => {
                 {i18n.t("Malaria Data Approval Report")}
             </Typography>
 
-            <DataApprovalList />
+            <DataApprovalList dataSetCode="0MAL_5" />
         </div>
     );
 };

--- a/src/webapp/reports/mal-data-approval/data-approval-list/Filters.tsx
+++ b/src/webapp/reports/mal-data-approval/data-approval-list/Filters.tsx
@@ -14,6 +14,7 @@ export interface DataSetsFiltersProps {
     values: DataSetsFilter;
     options: FilterOptions;
     onChange: React.Dispatch<React.SetStateAction<DataSetsFilter>>;
+    hideDataSets?: boolean;
 }
 
 export interface DataSetsFilter {
@@ -31,7 +32,7 @@ interface FilterOptions {
 
 export const Filters: React.FC<DataSetsFiltersProps> = React.memo(props => {
     const { config, api } = useAppContext();
-    const { values: filter, options: filterOptions, onChange } = props;
+    const { hideDataSets, values: filter, options: filterOptions, onChange } = props;
 
     const dataSetItems = useMemoOptionsFromNamedRef(filterOptions.dataSets);
     const periodItems = useMemoOptionsFromStrings(filterOptions.periods);
@@ -119,12 +120,14 @@ export const Filters: React.FC<DataSetsFiltersProps> = React.memo(props => {
                 selectableLevels={[1, 2, 3]}
             />
 
-            <DropdownStyled
-                items={dataSetItems}
-                values={filter.dataSetIds}
-                onChange={setDataSetIds}
-                label={i18n.t("Data sets")}
-            />
+            {!hideDataSets && (
+                <DropdownStyled
+                    items={dataSetItems}
+                    values={filter.dataSetIds}
+                    onChange={setDataSetIds}
+                    label={i18n.t("Data sets")}
+                />
+            )}
 
             <DropdownStyled
                 items={periodItems}


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694jgjpz

### :memo: Implementation

- [x] Get dataSet by code = `0MAL_5`
- [x] Hide dataSets filters dropdown since this report only works for this specific dataSet.

~@MiquelAdell  PR created as DRAFT since now the sqlView is throwing an error: `Query failed because a referenced table does not exist. Please ensure analytics job was run (SqlState: 42P01)`

![image](https://github.com/EyeSeeTea/d2-reports/assets/461124/9e7a6e3f-c230-47fe-93a8-672f7eba973d)

This is not related to the changes in this PR, but I was not able to identify the solution yet. Can you please try this in widp dev, so we can know if this is an error related to the dev server?~

UPDATE 2024-05-23: [This solution fix](https://community.dhis2.org/t/code-409-status-conflict-query-failed-because-a-referenced-table-does-not-exist-please-ensure-analytics-job-was-run-sqlstate-42p01/56728/2) the problem in the dev server, but not in my local server.

### :video_camera: Screenshots/Screen capture

![image](https://github.com/EyeSeeTea/d2-reports/assets/461124/dcd8de20-235e-4e5c-856c-0982dc375273)

### :fire: Notes to the tester

Generate report at `dist/index.html`

```bash
yarn build-report
```

#8694jgjpz