### PR TITLE
update response schema and status validation

### DIFF
--- a/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
+++ b/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
@@ -139,10 +139,10 @@ export class NHWADataApprovalDefaultRepository implements NHWADataApprovalReposi
 
         try {
             const response = await this.api
-                .post<any>("/completeDataSetRegistrations", {}, { completeDataSetRegistrations })
+                .post<{ status: "OK" | "ERROR" }>("/completeDataSetRegistrations", {}, { completeDataSetRegistrations })
                 .getData();
 
-            return response.status === "SUCCESS";
+            return response.status === "OK";
         } catch (error: any) {
             return false;
         }
@@ -176,7 +176,7 @@ export class NHWADataApprovalDefaultRepository implements NHWADataApprovalReposi
         try {
             const response = await promiseMap(dataSets, item =>
                 this.api
-                    .delete<any>("/completeDataSetRegistrations", {
+                    .delete<string>("/completeDataSetRegistrations", {
                         ds: item.dataSet,
                         pe: item.period,
                         ou: item.orgUnit,


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/86968fnj1

### :memo: Implementation

- [x] In the code, we expected a 'SUCCESS' response from the server; otherwise, we would display the error message. Starting from v38, the response is 'OK', which caused an incorrect error message to be shown.

### :video_camera: Screenshots/Screen capture

**Complete/Incomplete status**
[DHIS2-Reports_fix_error_message_complete_nhwa.webm](https://github.com/user-attachments/assets/161c3e59-d57e-4bae-90b1-f2a7c8150f35)

### :fire: Notes to the tester

#86968fnj1