### PR TITLE
validate response status instead http status

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-09-23T20:58:08.019Z\n"
-"PO-Revision-Date: 2024-09-23T20:58:08.019Z\n"
+"POT-Creation-Date: 2024-11-26T17:21:02.878Z\n"
+"PO-Revision-Date: 2024-11-26T17:21:02.878Z\n"
 
 msgid "<No value>"
 msgstr ""
@@ -138,6 +138,9 @@ msgid "Search by username..."
 msgstr ""
 
 msgid "Advanced filters"
+msgstr ""
+
+msgid "Failed to load org units"
 msgstr ""
 
 msgid "Period"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: i18next-conv\n"
-"POT-Creation-Date: 2024-09-23T20:58:08.019Z\n"
+"POT-Creation-Date: 2024-11-26T17:21:02.878Z\n"
 "PO-Revision-Date: 2018-10-25T09:02:35.143Z\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -138,6 +138,9 @@ msgid "Search by username..."
 msgstr ""
 
 msgid "Advanced filters"
+msgstr ""
+
+msgid "Failed to load org units"
 msgstr ""
 
 msgid "Period"

--- a/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
+++ b/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
@@ -139,10 +139,14 @@ export class NHWADataApprovalDefaultRepository implements NHWADataApprovalReposi
 
         try {
             const response = await this.api
-                .post<{ status: "OK" | "ERROR" }>("/completeDataSetRegistrations", {}, { completeDataSetRegistrations })
+                .post<{ status: "OK" | "ERROR"; response: { status: "SUCCESS" | "ERROR" } }>(
+                    "/completeDataSetRegistrations",
+                    {},
+                    { completeDataSetRegistrations }
+                )
                 .getData();
 
-            return response.status === "OK";
+            return response.response.status === "SUCCESS";
         } catch (error: any) {
             return false;
         }
@@ -183,6 +187,7 @@ export class NHWADataApprovalDefaultRepository implements NHWADataApprovalReposi
                     })
                     .getData()
             );
+            console.log("Response:incomplete", response);
 
             return _.every(response, item => item === "");
         } catch (error: any) {

--- a/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
+++ b/src/data/reports/nhwa-approval-status/NHWADataApprovalDefaultRepository.ts
@@ -187,7 +187,6 @@ export class NHWADataApprovalDefaultRepository implements NHWADataApprovalReposi
                     })
                     .getData()
             );
-            console.log("Response:incomplete", response);
 
             return _.every(response, item => item === "");
         } catch (error: any) {

--- a/src/webapp/reports/Reports.tsx
+++ b/src/webapp/reports/Reports.tsx
@@ -22,8 +22,6 @@ import i18n from "../../locales";
 const widget = process.env.REACT_APP_REPORT_VARIANT || "";
 
 const Component: React.FC = () => {
-    // return <MalDataApprovalStatusReport />;
-    return <NHWAFixTotals />;
     switch (widget) {
         case "nhwa-comments": {
             return <NHWACommentsReport />;


### PR DESCRIPTION
### :pushpin: References

-   **Issue:** Closes https://app.clickup.com/t/8694xwz4c

### :memo: Implementation

- [x] Validate status value in new `response` object.

Before v2.38.7:

```
// HTTP 200 OK
{
  status: "SUCCESS"
}
```

V2.38.7 and above

```
// HTTP 200 OK
{
  response: {
    status: "SUCCESS"
  }
}
```

### :video_camera: Screenshots/Screen capture

[Reports-DHIS2_nhwa_approval.webm](https://github.com/user-attachments/assets/df45b820-13de-4a73-997e-e9eac1e8f98c)


### :fire: Notes to the tester

```bash
yarn build-report
```

Report generated `dist/index.html`

#8694xwz4c